### PR TITLE
feat: 로그인 관심사 분리

### DIFF
--- a/src/main/java/com/woowacourse/auth/application/JwtTokenProvider.java
+++ b/src/main/java/com/woowacourse/auth/application/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.woowacourse.auth.application;
 
+import com.woowacourse.auth.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
@@ -37,24 +38,15 @@ public class JwtTokenProvider {
     }
 
     public String getPayload(final String token) {
-        return getClaimJws(token)
-                .getBody()
-                .getSubject();
-    }
-
-    public boolean validateToken(final String token) {
         try {
-            getClaimJws(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (JwtException e) {
+            throw new InvalidTokenException();
         }
-    }
-
-    private Jws<Claims> getClaimJws(final String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token);
     }
 }

--- a/src/main/java/com/woowacourse/auth/application/JwtTokenProvider.java
+++ b/src/main/java/com/woowacourse/auth/application/JwtTokenProvider.java
@@ -37,15 +37,24 @@ public class JwtTokenProvider {
     }
 
     public String getPayload(final String token) {
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+        return getClaimJws(token)
+                .getBody()
+                .getSubject();
     }
 
     public boolean validateToken(final String token) {
         try {
-            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return !claims.getBody().getExpiration().before(new Date());
+            getClaimJws(token);
+            return true;
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
+    }
+
+    private Jws<Claims> getClaimJws(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
     }
 }

--- a/src/main/java/com/woowacourse/auth/config/AuthConfig.java
+++ b/src/main/java/com/woowacourse/auth/config/AuthConfig.java
@@ -1,0 +1,34 @@
+package com.woowacourse.auth.config;
+
+import com.woowacourse.auth.presentation.AuthenticationArgumentResolver;
+import com.woowacourse.auth.presentation.LoginInterceptor;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AuthConfig implements WebMvcConfigurer {
+
+    private final LoginInterceptor loginInterceptor;
+    private final AuthenticationArgumentResolver authenticationArgumentResolver;
+
+    public AuthConfig(final LoginInterceptor loginInterceptor,
+                      final AuthenticationArgumentResolver authenticationArgumentResolver) {
+        this.loginInterceptor = loginInterceptor;
+        this.authenticationArgumentResolver = authenticationArgumentResolver;
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(loginInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/login", "/api/categories");
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationArgumentResolver);
+    }
+}

--- a/src/main/java/com/woowacourse/auth/config/AuthConfig.java
+++ b/src/main/java/com/woowacourse/auth/config/AuthConfig.java
@@ -23,8 +23,7 @@ public class AuthConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
-                .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/login", "/api/categories");
+                .addPathPatterns("/api/campus/*/reviews");
     }
 
     @Override

--- a/src/main/java/com/woowacourse/auth/exception/AuthenticationContextException.java
+++ b/src/main/java/com/woowacourse/auth/exception/AuthenticationContextException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.auth.exception;
+
+public class AuthenticationContextException extends RuntimeException {
+
+    public AuthenticationContextException() {
+        super("Authority 권한을 사용할 수 없습니다.");
+    }
+}

--- a/src/main/java/com/woowacourse/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/woowacourse/auth/exception/InvalidTokenException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.auth.exception;
+
+public class InvalidTokenException extends RuntimeException {
+
+    public InvalidTokenException() {
+        super("유효하지 않은 토큰입니다.");
+    }
+}

--- a/src/main/java/com/woowacourse/auth/exception/TokenNotFoundException.java
+++ b/src/main/java/com/woowacourse/auth/exception/TokenNotFoundException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.auth.exception;
+
+public class TokenNotFoundException extends RuntimeException {
+
+    public TokenNotFoundException() {
+        super("토큰이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/woowacourse/auth/presentation/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/woowacourse/auth/presentation/AuthenticationArgumentResolver.java
@@ -1,0 +1,31 @@
+package com.woowacourse.auth.presentation;
+
+import com.woowacourse.auth.support.AuthenticationPrincipal;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthenticationContext authenticationContext;
+
+    public AuthenticationArgumentResolver(final AuthenticationContext authenticationContext) {
+        this.authenticationContext = authenticationContext;
+    }
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+    }
+
+    @Override
+    public String resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory)
+            throws Exception {
+        return authenticationContext.getAuthority();
+    }
+}

--- a/src/main/java/com/woowacourse/auth/presentation/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/woowacourse/auth/presentation/AuthenticationArgumentResolver.java
@@ -26,6 +26,6 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
     public String resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
                                   final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory)
             throws Exception {
-        return authenticationContext.getAuthority();
+        return authenticationContext.getPrincipal();
     }
 }

--- a/src/main/java/com/woowacourse/auth/presentation/AuthenticationContext.java
+++ b/src/main/java/com/woowacourse/auth/presentation/AuthenticationContext.java
@@ -1,0 +1,27 @@
+package com.woowacourse.auth.presentation;
+
+import com.woowacourse.auth.exception.AuthenticationContextException;
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Component
+@RequestScope
+public class AuthenticationContext {
+
+    private String authority;
+
+    public String getAuthority() {
+        if (Objects.isNull(authority)) {
+            throw new AuthenticationContextException();
+        }
+        return authority;
+    }
+
+    public void setAuthority(final String authority) {
+        if (Objects.nonNull(this.authority)) {
+            throw new AuthenticationContextException();
+        }
+        this.authority = authority;
+    }
+}

--- a/src/main/java/com/woowacourse/auth/presentation/AuthenticationContext.java
+++ b/src/main/java/com/woowacourse/auth/presentation/AuthenticationContext.java
@@ -9,19 +9,19 @@ import org.springframework.web.context.annotation.RequestScope;
 @RequestScope
 public class AuthenticationContext {
 
-    private String authority;
+    private String principal;
 
-    public String getAuthority() {
-        if (Objects.isNull(authority)) {
+    public String getPrincipal() {
+        if (Objects.isNull(principal)) {
             throw new AuthenticationContextException();
         }
-        return authority;
+        return principal;
     }
 
-    public void setAuthority(final String authority) {
-        if (Objects.nonNull(this.authority)) {
+    public void setPrincipal(final String principal) {
+        if (Objects.nonNull(this.principal)) {
             throw new AuthenticationContextException();
         }
-        this.authority = authority;
+        this.principal = principal;
     }
 }

--- a/src/main/java/com/woowacourse/auth/presentation/LoginInterceptor.java
+++ b/src/main/java/com/woowacourse/auth/presentation/LoginInterceptor.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
@@ -25,19 +26,12 @@ public class LoginInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler)
             throws Exception {
-        if (isPreflight(request)) {
+        if (CorsUtils.isPreFlightRequest(request)) {
             return true;
         }
         final String token = AuthorizationExtractor.extract(request)
                 .orElseThrow(TokenNotFoundException::new);
-        if (jwtTokenProvider.validateToken(token)) {
-            authenticationContext.setPrincipal(jwtTokenProvider.getPayload(token));
-            return true;
-        }
-        throw new InvalidTokenException();
-    }
-
-    private boolean isPreflight(HttpServletRequest request) {
-        return HttpMethod.OPTIONS.matches(request.getMethod());
+        authenticationContext.setPrincipal(jwtTokenProvider.getPayload(token));
+        return true;
     }
 }

--- a/src/main/java/com/woowacourse/auth/presentation/LoginInterceptor.java
+++ b/src/main/java/com/woowacourse/auth/presentation/LoginInterceptor.java
@@ -31,7 +31,7 @@ public class LoginInterceptor implements HandlerInterceptor {
         final String token = AuthorizationExtractor.extract(request)
                 .orElseThrow(TokenNotFoundException::new);
         if (jwtTokenProvider.validateToken(token)) {
-            authenticationContext.setAuthority(jwtTokenProvider.getPayload(token));
+            authenticationContext.setPrincipal(jwtTokenProvider.getPayload(token));
             return true;
         }
         throw new InvalidTokenException();

--- a/src/main/java/com/woowacourse/auth/presentation/LoginInterceptor.java
+++ b/src/main/java/com/woowacourse/auth/presentation/LoginInterceptor.java
@@ -1,0 +1,43 @@
+package com.woowacourse.auth.presentation;
+
+import com.woowacourse.auth.application.JwtTokenProvider;
+import com.woowacourse.auth.exception.InvalidTokenException;
+import com.woowacourse.auth.exception.TokenNotFoundException;
+import com.woowacourse.auth.support.AuthorizationExtractor;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class LoginInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationContext authenticationContext;
+
+    public LoginInterceptor(final JwtTokenProvider jwtTokenProvider,
+                            final AuthenticationContext authenticationContext) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.authenticationContext = authenticationContext;
+    }
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler)
+            throws Exception {
+        if (isPreflight(request)) {
+            return true;
+        }
+        final String token = AuthorizationExtractor.extract(request)
+                .orElseThrow(TokenNotFoundException::new);
+        if (jwtTokenProvider.validateToken(token)) {
+            authenticationContext.setAuthority(jwtTokenProvider.getPayload(token));
+            return true;
+        }
+        throw new InvalidTokenException();
+    }
+
+    private boolean isPreflight(HttpServletRequest request) {
+        return HttpMethod.OPTIONS.matches(request.getMethod());
+    }
+}

--- a/src/main/java/com/woowacourse/auth/support/AuthenticationPrincipal.java
+++ b/src/main/java/com/woowacourse/auth/support/AuthenticationPrincipal.java
@@ -1,0 +1,11 @@
+package com.woowacourse.auth.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationPrincipal {
+}

--- a/src/test/java/com/woowacourse/auth/application/JwtTokenProviderTest.java
+++ b/src/test/java/com/woowacourse/auth/application/JwtTokenProviderTest.java
@@ -1,7 +1,9 @@
 package com.woowacourse.auth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.auth.exception.InvalidTokenException;
 import org.junit.jupiter.api.Test;
 
 class JwtTokenProviderTest {
@@ -25,18 +27,11 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    void 기간이_남으면_true를_반환한다() {
-        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, VALIDITY_IN_MILLISECONDS);
-        String token = jwtTokenProvider.createToken("1");
-
-        assertThat(jwtTokenProvider.validateToken(token)).isTrue();
-    }
-
-    @Test
-    void 기간이_만료되면_false를_반환한다() {
+    void 기간이_만료되면_에러가_발생한다() {
         JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, 0);
         String token = jwtTokenProvider.createToken("1");
 
-        assertThat(jwtTokenProvider.validateToken(token)).isFalse();
+        assertThatThrownBy(() -> jwtTokenProvider.getPayload(token))
+                .isInstanceOf(InvalidTokenException.class);
     }
 }

--- a/src/test/java/com/woowacourse/document/Documentation.java
+++ b/src/test/java/com/woowacourse/document/Documentation.java
@@ -4,7 +4,9 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
 import com.woowacourse.auth.application.AuthService;
+import com.woowacourse.auth.application.JwtTokenProvider;
 import com.woowacourse.auth.presentation.AuthController;
+import com.woowacourse.auth.presentation.AuthenticationContext;
 import com.woowacourse.matzip.application.CategoryService;
 import com.woowacourse.matzip.presentation.CategoryController;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
@@ -30,6 +32,10 @@ class Documentation {
     protected CategoryService categoryService;
     @MockBean
     protected AuthService authService;
+    @MockBean
+    protected JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    protected AuthenticationContext authenticationContext;
 
     @BeforeEach
     void setDocsGiven(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {


### PR DESCRIPTION
## issue: #9 

## as-is
- 로그인 로직 처리를 비즈니스 로직에서 실행한다.

## to-be
- 로그인 인터셉터를 구현한다.
- AuthContext를 생성한다.
- ArgumentResolver로 **githunId**값을 반환받는다.

인터셉터에 pattern 등록해서 사용하시면 됩니다.
Token의 Subject는 githubId입니다. 이 값 기반으로 Member정보를 찾아오면 됩니다.

에러관련해서, InternalException과 BadRequestException 등 RuntimeException을 상속받는 클래스를 만들어 이를 기준으로 예외를 구분하면 어떨까합니다. 혹은 에러 코드와 에러 메시지를 보관하는 enum 클래스를 만들어도 되구요.. 예외 핸들링 관련해서 이야기를 더 나눠봐야 할 것 같아요