### PR TITLE
feat: 식당, 리뷰 entity 구현

### DIFF
--- a/src/main/java/com/woowacourse/matzip/domain/campus/Campus.java
+++ b/src/main/java/com/woowacourse/matzip/domain/campus/Campus.java
@@ -20,7 +20,7 @@ public class Campus {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
+    @Column(name = "name", length = 20, nullable = false, unique = true)
     @Enumerated(EnumType.STRING)
     private CampusName name;
 

--- a/src/main/java/com/woowacourse/matzip/domain/category/Category.java
+++ b/src/main/java/com/woowacourse/matzip/domain/category/Category.java
@@ -21,7 +21,7 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(name = "name", length = 10, nullable = false, unique = true)
     private String name;
 
     protected Category() {

--- a/src/main/java/com/woowacourse/matzip/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/woowacourse/matzip/domain/restaurant/Restaurant.java
@@ -1,0 +1,75 @@
+package com.woowacourse.matzip.domain.restaurant;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "restaurant")
+@Getter
+public class Restaurant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "category_id", nullable = false)
+    private Long categoryId;
+
+    @Column(name = "campus_id", nullable = false)
+    private Long campusId;
+
+    @Column(name = "name", length = 20, nullable = false)
+    private String name;
+
+    @Column(name = "address", nullable = false, unique = true)
+    private String address;
+
+    @Column(name = "distance", nullable = false)
+    private Long distance;
+
+    @Column(name = "kakao_map_url", nullable = false)
+    private String kakaoMapUrl;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    protected Restaurant() {
+    }
+
+    @Builder
+    public Restaurant(final Long id, final Long categoryId, final Long campusId, final String name,
+                      final String address, final Long distance, final String kakaoMapUrl, final String imageUrl) {
+        this.id = id;
+        this.categoryId = categoryId;
+        this.campusId = campusId;
+        this.name = name;
+        this.address = address;
+        this.distance = distance;
+        this.kakaoMapUrl = kakaoMapUrl;
+        this.imageUrl = imageUrl;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Restaurant that = (Restaurant) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
@@ -1,0 +1,6 @@
+package com.woowacourse.matzip.domain.restaurant;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+}

--- a/src/main/java/com/woowacourse/matzip/domain/review/Review.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/Review.java
@@ -1,0 +1,67 @@
+package com.woowacourse.matzip.domain.review;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "review")
+@Getter
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "restaurant_id", nullable = false)
+    private Long restaurantId;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
+    @Column(name = "menu", length = 20, nullable = false)
+    private String menu;
+
+    protected Review() {
+    }
+
+    @Builder
+    public Review(final Long id, final Long memberId, final Long restaurantId, final String content,
+                  final Integer score, final String menu) {
+        this.id = id;
+        this.memberId = memberId;
+        this.restaurantId = restaurantId;
+        this.content = content;
+        this.score = score;
+        this.menu = menu;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Review review = (Review) o;
+        return Objects.equals(id, review.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
@@ -1,0 +1,6 @@
+package com.woowacourse.matzip.domain.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}


### PR DESCRIPTION
## issue: #8

## as-is
- Restaurant entity 미구현
- Review entity 미구현

## to-do
- Restaurant entity 구현
- Review entity 구현
- Restaurant와 Review는 id 값을 통한 간접 참조
- `@Column`에 실제 DB의 컬럼 명 매핑 `@Column(name = "restaurant_id")`

 `Restaurant`의 `distance` 필드와 `Review`의 `score` 의 타입을 현재는 wrapper 타입으로 지정해 두었습니다.(`Long`, `Integer`) 이 부분에 대해서, 어차피 `(nullable = false)` 적용되어 있으니 primitive 타입을 쓰는 것이 맞을 지 의견을 내 주시면 감사하겠습니다.