### PR TITLE
feat: 식당 목록 조회 시 평균 별점을 함께 조회하는 기능 구현

### DIFF
--- a/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -31,15 +31,7 @@ public class RestaurantService {
     }
 
     private RestaurantTitleResponse toResponse(Restaurant restaurant) {
-        double rating = getAverageRating(restaurant);
-        return RestaurantTitleResponse.of(restaurant, rating);
-    }
-
-    private double getAverageRating(Restaurant restaurant) {
-        List<Integer> ratings = reviewRepository.findRatingsByRestaurantId(restaurant.getId());
-        int sum = ratings.stream()
-                .mapToInt(Integer::intValue)
-                .sum();
-        return sum / (double) ratings.size();
+        Double rating = reviewRepository.findAverageRatingByRestaurantId(restaurant.getId());
+        return RestaurantTitleResponse.of(restaurant, rating != null ? rating : 0.0);
     }
 }

--- a/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -1,7 +1,9 @@
 package com.woowacourse.matzip.application;
 
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
 import com.woowacourse.matzip.domain.restaurant.RestaurantRepository;
+import com.woowacourse.matzip.domain.review.ReviewRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
@@ -13,16 +15,31 @@ import org.springframework.transaction.annotation.Transactional;
 public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
+    private final ReviewRepository reviewRepository;
 
-    public RestaurantService(final RestaurantRepository restaurantRepository) {
+    public RestaurantService(final RestaurantRepository restaurantRepository, final ReviewRepository reviewRepository) {
         this.restaurantRepository = restaurantRepository;
+        this.reviewRepository = reviewRepository;
     }
 
     public List<RestaurantTitleResponse> findByCampusIdOrderByIdDesc(final Long campusId, final Long categoryId,
                                                                      final Pageable pageable) {
         return restaurantRepository.findPageByCampusIdOrderByIdDesc(campusId, categoryId, pageable)
                 .stream()
-                .map(restaurant -> RestaurantTitleResponse.of(restaurant, 0))
+                .map(this::toResponse)
                 .collect(Collectors.toList());
+    }
+
+    private RestaurantTitleResponse toResponse(Restaurant restaurant) {
+        double rating = getAverageRating(restaurant);
+        return RestaurantTitleResponse.of(restaurant, rating);
+    }
+
+    private double getAverageRating(Restaurant restaurant) {
+        List<Integer> ratings = reviewRepository.findRatingsByRestaurantId(restaurant.getId());
+        int sum = ratings.stream()
+                .mapToInt(Integer::intValue)
+                .sum();
+        return sum / (double) ratings.size();
     }
 }

--- a/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -1,6 +1,6 @@
 package com.woowacourse.matzip.application;
 
-import com.woowacourse.matzip.application.response.RestaurantResponse;
+import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import com.woowacourse.matzip.domain.restaurant.RestaurantRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,11 +18,11 @@ public class RestaurantService {
         this.restaurantRepository = restaurantRepository;
     }
 
-    public List<RestaurantResponse> findByCampusIdOrderByIdDesc(final Long campusId, final Long categoryId,
-                                                                final Pageable pageable) {
+    public List<RestaurantTitleResponse> findByCampusIdOrderByIdDesc(final Long campusId, final Long categoryId,
+                                                                     final Pageable pageable) {
         return restaurantRepository.findPageByCampusIdOrderByIdDesc(campusId, categoryId, pageable)
                 .stream()
-                .map(RestaurantResponse::from)
+                .map(restaurant -> RestaurantTitleResponse.of(restaurant, 0))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -31,7 +31,8 @@ public class RestaurantService {
     }
 
     private RestaurantTitleResponse toResponse(Restaurant restaurant) {
-        Double rating = reviewRepository.findAverageRatingByRestaurantId(restaurant.getId());
-        return RestaurantTitleResponse.of(restaurant, rating != null ? rating : 0.0);
+        double rating = reviewRepository.findAverageRatingByRestaurantId(restaurant.getId())
+                .orElse(0.0);
+        return RestaurantTitleResponse.of(restaurant, rating);
     }
 }

--- a/src/main/java/com/woowacourse/matzip/application/response/RestaurantResponse.java
+++ b/src/main/java/com/woowacourse/matzip/application/response/RestaurantResponse.java
@@ -9,14 +9,14 @@ public class RestaurantResponse {
     private Long id;
     private String name;
     private String address;
-    private Long distance;
+    private long distance;
     private String kakaoMapUrl;
     private String imageUrl;
 
     private RestaurantResponse() {
     }
 
-    private RestaurantResponse(final Long id, final String name, final String address, final Long distance,
+    private RestaurantResponse(final Long id, final String name, final String address, final long distance,
                                final String kakaoMapUrl, final String imageUrl) {
         this.id = id;
         this.name = name;

--- a/src/main/java/com/woowacourse/matzip/application/response/RestaurantTitleResponse.java
+++ b/src/main/java/com/woowacourse/matzip/application/response/RestaurantTitleResponse.java
@@ -1,0 +1,30 @@
+package com.woowacourse.matzip.application.response;
+
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import lombok.Getter;
+
+@Getter
+public class RestaurantTitleResponse {
+
+    private Long id;
+    private String name;
+    private long distance;
+    private double rating;
+    private String imageUrl;
+
+    private RestaurantTitleResponse() {
+    }
+
+    private RestaurantTitleResponse(Long id, String name, long distance, double rating, String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.distance = distance;
+        this.rating = rating;
+        this.imageUrl = imageUrl;
+    }
+
+    public static RestaurantTitleResponse of(Restaurant restaurant, double rating) {
+        return new RestaurantTitleResponse(restaurant.getId(), restaurant.getName(), restaurant.getDistance(), rating,
+                restaurant.getImageUrl());
+    }
+}

--- a/src/main/java/com/woowacourse/matzip/application/response/ReviewResponse.java
+++ b/src/main/java/com/woowacourse/matzip/application/response/ReviewResponse.java
@@ -10,17 +10,18 @@ public class ReviewResponse {
     private Long id;
     private ReviewAuthor author;
     private String content;
-    private int score;
+    private int rating;
     private String menu;
 
     private ReviewResponse() {
     }
 
-    public ReviewResponse(final Long id, final ReviewAuthor author, final String content, final int score, final String menu) {
+    public ReviewResponse(final Long id, final ReviewAuthor author, final String content, final int rating,
+                          final String menu) {
         this.id = id;
         this.author = author;
         this.content = content;
-        this.score = score;
+        this.rating = rating;
         this.menu = menu;
     }
 
@@ -29,7 +30,7 @@ public class ReviewResponse {
                 review.getId(),
                 ReviewAuthor.from(review.getMember()),
                 review.getContent(),
-                review.getScore(),
+                review.getRating(),
                 review.getMenu()
         );
     }

--- a/src/main/java/com/woowacourse/matzip/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/woowacourse/matzip/domain/restaurant/Restaurant.java
@@ -32,7 +32,7 @@ public class Restaurant {
     private String address;
 
     @Column(name = "distance", nullable = false)
-    private Long distance;
+    private long distance;
 
     @Column(name = "kakao_map_url", nullable = false)
     private String kakaoMapUrl;
@@ -45,7 +45,7 @@ public class Restaurant {
 
     @Builder
     public Restaurant(final Long id, final Long categoryId, final Long campusId, final String name,
-                      final String address, final Long distance, final String kakaoMapUrl, final String imageUrl) {
+                      final String address, final long distance, final String kakaoMapUrl, final String imageUrl) {
         this.id = id;
         this.categoryId = categoryId;
         this.campusId = campusId;

--- a/src/main/java/com/woowacourse/matzip/domain/review/Review.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/Review.java
@@ -37,8 +37,8 @@ public class Review {
     @Column(name = "content")
     private String content;
 
-    @Column(name = "score", nullable = false)
-    private int score;
+    @Column(name = "rating", nullable = false)
+    private int rating;
 
     @Column(name = "menu", length = 20, nullable = false)
     private String menu;
@@ -47,19 +47,19 @@ public class Review {
     }
 
     @Builder
-    public Review(final Long id, final Member member, final Long restaurantId, final String content, final int score,
+    public Review(final Long id, final Member member, final Long restaurantId, final String content, final int rating,
                   final String menu) {
-        validateScoreLength(score);
+        validateRating(rating);
         this.id = id;
         this.member = member;
         this.restaurantId = restaurantId;
         this.content = content;
-        this.score = score;
+        this.rating = rating;
         this.menu = menu;
     }
 
-    private void validateScoreLength(final int score) {
-        if (score < MIN_SCORE || score > MAX_SCORE) {
+    private void validateRating(final int rating) {
+        if (rating < MIN_SCORE || rating > MAX_SCORE) {
             throw new InvalidReviewException("리뷰 점수는 0점부터 5점까지만 가능합니다.");
         }
     }

--- a/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
@@ -8,9 +8,9 @@ import org.springframework.data.jpa.repository.Query;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query(
-            value = "select r.rating from Review r where (r.restaurantId = :restaurantId)"
+            value = "select avg(r.rating) from Review r where (r.restaurantId = :restaurantId)"
     )
-    List<Integer> findRatingsByRestaurantId(Long restaurantId);
+    Double findAverageRatingByRestaurantId(Long restaurantId);
 
     List<Review> findReviewsByRestaurantIdOrderByIdDesc(Long restaurantId, Pageable pageable);
 }

--- a/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.woowacourse.matzip.domain.review;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,7 +11,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query(
             value = "select avg(r.rating) from Review r where (r.restaurantId = :restaurantId)"
     )
-    Double findAverageRatingByRestaurantId(Long restaurantId);
+    Optional<Double> findAverageRatingByRestaurantId(Long restaurantId);
 
     List<Review> findReviewsByRestaurantIdOrderByIdDesc(Long restaurantId, Pageable pageable);
 }

--- a/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
@@ -3,8 +3,14 @@ package com.woowacourse.matzip.domain.review;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Query(
+            value = "select r.rating from Review r where (r.restaurantId = :restaurantId)"
+    )
+    List<Integer> findRatingsByRestaurantId(Long restaurantId);
 
     List<Review> findReviewsByRestaurantIdOrderByIdDesc(Long restaurantId, Pageable pageable);
 }

--- a/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
+++ b/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
@@ -1,7 +1,7 @@
 package com.woowacourse.matzip.presentation;
 
 import com.woowacourse.matzip.application.RestaurantService;
-import com.woowacourse.matzip.application.response.RestaurantResponse;
+import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -22,9 +22,9 @@ public class RestaurantController {
     }
 
     @GetMapping
-    public ResponseEntity<List<RestaurantResponse>> show(@PathVariable final Long campusId,
-                                                         @RequestParam(required = false) final Long categoryId,
-                                                         final Pageable pageable) {
+    public ResponseEntity<List<RestaurantTitleResponse>> showPage(@PathVariable final Long campusId,
+                                                                  @RequestParam(required = false) final Long categoryId,
+                                                                  final Pageable pageable) {
         return ResponseEntity.ok(restaurantService.findByCampusIdOrderByIdDesc(campusId, categoryId, pageable));
     }
 }

--- a/src/main/java/com/woowacourse/matzip/presentation/request/ReviewCreateRequest.java
+++ b/src/main/java/com/woowacourse/matzip/presentation/request/ReviewCreateRequest.java
@@ -6,15 +6,15 @@ import com.woowacourse.matzip.domain.review.Review;
 public class ReviewCreateRequest {
 
     private String content;
-    private int score;
+    private int rating;
     private String menu;
 
     private ReviewCreateRequest() {
     }
 
-    public ReviewCreateRequest(final String content, final int score, final String menu) {
+    public ReviewCreateRequest(final String content, final int rating, final String menu) {
         this.content = content;
-        this.score = score;
+        this.rating = rating;
         this.menu = menu;
     }
 
@@ -23,7 +23,7 @@ public class ReviewCreateRequest {
                 .member(member)
                 .restaurantId(restaurantId)
                 .content(content)
-                .score(score)
+                .rating(rating)
                 .menu(menu)
                 .build();
     }
@@ -32,8 +32,8 @@ public class ReviewCreateRequest {
         return content;
     }
 
-    public int getScore() {
-        return score;
+    public int getRating() {
+        return rating;
     }
 
     public String getMenu() {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -32,7 +32,7 @@ CREATE TABLE review
     member_id     bigint       NOT NULL,
     restaurant_id bigint       NOT NULL,
     content       varchar(255) NULL,
-    score         int          NOT NULL,
+    rating        int          NOT NULL,
     menu          varchar(20)  NOT NULL,
     PRIMARY KEY (id)
 );

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -464,6 +464,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_캠퍼스_별_카테고리가_일치하는_식당_목록_조회">캠퍼스 별 카테고리가 일치하는 식당 목록 조회</a></li>
 </ul>
 </li>
+<li><a href="#Review">리뷰</a>
+<ul class="sectlevel2">
+<li><a href="#_리뷰_작성">리뷰 작성</a></li>
+<li><a href="#_리뷰_조회">리뷰 조회</a></li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
@@ -585,17 +591,22 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 147
+Content-Length: 212
 
 [ {
+  "id" : 1,
   "name" : "한식"
 }, {
+  "id" : 2,
   "name" : "중식"
 }, {
+  "id" : 3,
   "name" : "일식"
 }, {
+  "id" : 4,
   "name" : "양식"
 }, {
+  "id" : 5,
   "name" : "카페/디저트"
 } ]</code></pre>
 </div>
@@ -624,28 +635,25 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 666
+Content-Length: 375
 
 [ {
   "id" : 3,
   "name" : "마담밍",
-  "address" : "서울 강남구 선릉로86길 5-4 1층",
   "distance" : 1,
-  "kakaoMapUrl" : "https://place.map.kakao.com/18283045",
+  "rating" : 4.0,
   "imageUrl" : "www.image.com"
 }, {
   "id" : 2,
   "name" : "뽕나무쟁이 선릉본점",
-  "address" : "서울 강남구 역삼로65길 31",
   "distance" : 1,
-  "kakaoMapUrl" : "https://place.map.kakao.com/11190567",
+  "rating" : 4.0,
   "imageUrl" : "www.image.com"
 }, {
   "id" : 1,
   "name" : "배가무닭볶음탕",
-  "address" : "서울 강남구 선릉로86길 30 1층",
   "distance" : 1,
-  "kakaoMapUrl" : "https://place.map.kakao.com/733513512",
+  "rating" : 4.0,
   "imageUrl" : "www.image.com"
 } ]</code></pre>
 </div>
@@ -669,22 +677,124 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 453
+Content-Length: 261
 
 [ {
   "id" : 2,
   "name" : "뽕나무쟁이 선릉본점",
-  "address" : "서울 강남구 역삼로65길 31",
   "distance" : 1,
-  "kakaoMapUrl" : "https://place.map.kakao.com/11190567",
+  "rating" : 4.0,
   "imageUrl" : "www.image.com"
 }, {
   "id" : 1,
   "name" : "배가무닭볶음탕",
-  "address" : "서울 강남구 선릉로86길 30 1층",
   "distance" : 1,
-  "kakaoMapUrl" : "https://place.map.kakao.com/733513512",
+  "rating" : 4.0,
   "imageUrl" : "www.image.com"
+} ]</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="Review"><a class="link" href="#Review">리뷰</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_리뷰_작성"><a class="link" href="#_리뷰_작성">리뷰 작성</a></h3>
+<div class="sect3">
+<h4 id="_리뷰_작성_http_request"><a class="link" href="#_리뷰_작성_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/restaurants/1/reviews HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer jwt.token.here
+Content-Length: 89
+Host: localhost:8080
+
+{
+  "content" : "맛있네요.",
+  "rating" : 4,
+  "menu" : "무닭볶음탕 (중)"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리뷰_작성_http_response"><a class="link" href="#_리뷰_작성_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리뷰_조회"><a class="link" href="#_리뷰_조회">리뷰 조회</a></h3>
+<div class="sect3">
+<h4 id="_리뷰_조회_http_request"><a class="link" href="#_리뷰_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/restaurants/1/reviews?page=0&amp;size=5 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리뷰_조회_http_response"><a class="link" href="#_리뷰_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 929
+
+[ {
+  "id" : 1,
+  "author" : {
+    "username" : "후니",
+    "profileImage" : "url"
+  },
+  "content" : "무가 맛있어요",
+  "rating" : 5,
+  "menu" : "무닭볶음탕 (중)"
+}, {
+  "id" : 2,
+  "author" : {
+    "username" : "오찌",
+    "profileImage" : "url"
+  },
+  "content" : "맛없어요.",
+  "rating" : 2,
+  "menu" : "무닭볶음탕 (대)"
+}, {
+  "id" : 3,
+  "author" : {
+    "username" : "태태",
+    "profileImage" : "url"
+  },
+  "content" : "평범해요.",
+  "rating" : 3,
+  "menu" : "무닭볶음탕 (중)"
+}, {
+  "id" : 4,
+  "author" : {
+    "username" : "샐리",
+    "profileImage" : "url"
+  },
+  "content" : "맛있어요.",
+  "rating" : 4,
+  "menu" : "무닭볶음탕 (대)"
+}, {
+  "id" : 5,
+  "author" : {
+    "username" : "블링",
+    "profileImage" : "url"
+  },
+  "content" : "또오고 싶어요.",
+  "rating" : 5,
+  "menu" : "통마늘 닭똥집볶음"
 } ]</code></pre>
 </div>
 </div>
@@ -695,7 +805,7 @@ Content-Length: 453
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-06-13 16:22:35 +0900
+Last updated 2022-06-16 15:56:06 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/github.min.css">

--- a/src/test/java/com/woowacourse/document/DocumentationFixture.java
+++ b/src/test/java/com/woowacourse/document/DocumentationFixture.java
@@ -2,7 +2,7 @@ package com.woowacourse.document;
 
 import com.woowacourse.matzip.application.response.CampusResponse;
 import com.woowacourse.matzip.application.response.CategoryResponse;
-import com.woowacourse.matzip.application.response.RestaurantResponse;
+import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import com.woowacourse.matzip.application.response.ReviewResponse;
 import com.woowacourse.matzip.application.response.ReviewResponse.ReviewAuthor;
 import com.woowacourse.matzip.domain.campus.Campus;
@@ -32,14 +32,20 @@ public class DocumentationFixture {
             .map(CampusResponse::from)
             .collect(Collectors.toList());
 
-    private static final ReviewResponse REVIEW_1 = new ReviewResponse(1L, new ReviewAuthor("후니", "url"), "무가 맛있어요", 5, "무닭볶음탕 (중)");
-    private static final ReviewResponse REVIEW_2 = new ReviewResponse(2L, new ReviewAuthor("오찌", "url"), "맛없어요.", 2, "무닭볶음탕 (대)");
-    private static final ReviewResponse REVIEW_3 = new ReviewResponse(3L, new ReviewAuthor("태태", "url"), "평범해요.", 3, "무닭볶음탕 (중)");
-    private static final ReviewResponse REVIEW_4 = new ReviewResponse(4L, new ReviewAuthor("샐리", "url"), "맛있어요.", 4, "무닭볶음탕 (대)");
-    private static final ReviewResponse REVIEW_5 = new ReviewResponse(5L, new ReviewAuthor("블링", "url"), "또오고 싶어요.", 5, "통마늘 닭똥집볶음");
+    private static final ReviewResponse REVIEW_1 = new ReviewResponse(1L, new ReviewAuthor("후니", "url"), "무가 맛있어요", 5,
+            "무닭볶음탕 (중)");
+    private static final ReviewResponse REVIEW_2 = new ReviewResponse(2L, new ReviewAuthor("오찌", "url"), "맛없어요.", 2,
+            "무닭볶음탕 (대)");
+    private static final ReviewResponse REVIEW_3 = new ReviewResponse(3L, new ReviewAuthor("태태", "url"), "평범해요.", 3,
+            "무닭볶음탕 (중)");
+    private static final ReviewResponse REVIEW_4 = new ReviewResponse(4L, new ReviewAuthor("샐리", "url"), "맛있어요.", 4,
+            "무닭볶음탕 (대)");
+    private static final ReviewResponse REVIEW_5 = new ReviewResponse(5L, new ReviewAuthor("블링", "url"), "또오고 싶어요.", 5,
+            "통마늘 닭똥집볶음");
 
-    public static final List<ReviewResponse> REVIEW_RESPONSES = List.of(REVIEW_1, REVIEW_2, REVIEW_3, REVIEW_4, REVIEW_5);
-  
+    public static final List<ReviewResponse> REVIEW_RESPONSES = List.of(REVIEW_1, REVIEW_2, REVIEW_3, REVIEW_4,
+            REVIEW_5);
+
     private static final Restaurant SEOLLEUNG_RESTAURANT_1 = new Restaurant(1L, 1L, 2L, "배가무닭볶음탕",
             "서울 강남구 선릉로86길 30 1층", 1L,
             "https://place.map.kakao.com/733513512", "www.image.com");
@@ -50,13 +56,13 @@ public class DocumentationFixture {
             "서울 강남구 선릉로86길 5-4 1층", 1L,
             "https://place.map.kakao.com/18283045", "www.image.com");
 
-    public static final List<RestaurantResponse> SEOLLEUNG_RESTAURANT_RESPONSES = Stream.of(SEOLLEUNG_RESTAURANT_3,
+    public static final List<RestaurantTitleResponse> SEOLLEUNG_RESTAURANT_RESPONSES = Stream.of(SEOLLEUNG_RESTAURANT_3,
                     SEOLLEUNG_RESTAURANT_2, SEOLLEUNG_RESTAURANT_1)
-            .map(RestaurantResponse::from)
+            .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
             .collect(Collectors.toList());
 
-    public static final List<RestaurantResponse> SEOLLEUNG_KOREAN_RESTAURANT_RESPONSES = Stream.of(
+    public static final List<RestaurantTitleResponse> SEOLLEUNG_KOREAN_RESTAURANT_RESPONSES = Stream.of(
                     SEOLLEUNG_RESTAURANT_2, SEOLLEUNG_RESTAURANT_1)
-            .map(RestaurantResponse::from)
+            .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
             .collect(Collectors.toList());
 }

--- a/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -2,7 +2,7 @@ package com.woowacourse.matzip.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.woowacourse.matzip.application.response.RestaurantResponse;
+import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import com.woowacourse.support.SpringServiceTest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -17,7 +17,7 @@ class RestaurantServiceTest {
 
     @Test
     void 캠퍼스id가_일치하는_식당_목록_페이지를_반환한다() {
-        List<RestaurantResponse> responses = restaurantService.findByCampusIdOrderByIdDesc(2L, null,
+        List<RestaurantTitleResponse> responses = restaurantService.findByCampusIdOrderByIdDesc(2L, null,
                 Pageable.ofSize(10));
 
         assertThat(responses).hasSize(3);
@@ -25,7 +25,7 @@ class RestaurantServiceTest {
 
     @Test
     void 캠퍼스id와_카테고리id가_일치하는_식당_목록_페이지를_반환한다() {
-        List<RestaurantResponse> responses = restaurantService.findByCampusIdOrderByIdDesc(2L, 1L,
+        List<RestaurantTitleResponse> responses = restaurantService.findByCampusIdOrderByIdDesc(2L, 1L,
                 Pageable.ofSize(10));
 
         assertThat(responses).hasSize(2);

--- a/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.matzip.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import com.woowacourse.matzip.domain.member.Member;
@@ -13,6 +14,7 @@ import com.woowacourse.support.SpringServiceTest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 @SpringServiceTest
@@ -29,18 +31,29 @@ class RestaurantServiceTest {
 
     @Test
     void 캠퍼스id가_일치하는_식당_목록_페이지를_반환한다() {
-        List<RestaurantTitleResponse> responses = restaurantService.findByCampusIdOrderByIdDesc(2L, null,
-                Pageable.ofSize(10));
+        List<RestaurantTitleResponse> page1 = restaurantService.findByCampusIdOrderByIdDesc(2L, null,
+                Pageable.ofSize(2));
+        List<RestaurantTitleResponse> page2 = restaurantService.findByCampusIdOrderByIdDesc(2L, null,
+                PageRequest.of(1, 2));
 
-        assertThat(responses).hasSize(3);
+        assertAll(
+                () -> assertThat(page1).hasSize(2)
+                        .extracting(RestaurantTitleResponse::getName)
+                        .containsExactly("마담밍", "뽕나무쟁이 선릉본점"),
+                () -> assertThat(page2).hasSize(1)
+                        .extracting(RestaurantTitleResponse::getName)
+                        .containsExactly("배가무닭볶음탕")
+        );
     }
 
     @Test
     void 캠퍼스id와_카테고리id가_일치하는_식당_목록_페이지를_반환한다() {
         List<RestaurantTitleResponse> responses = restaurantService.findByCampusIdOrderByIdDesc(2L, 1L,
-                Pageable.ofSize(10));
+                Pageable.ofSize(2));
 
-        assertThat(responses).hasSize(2);
+        assertThat(responses).hasSize(2)
+                .extracting(RestaurantTitleResponse::getName)
+                .containsExactly("뽕나무쟁이 선릉본점", "배가무닭볶음탕");
     }
 
     @Test

--- a/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -3,6 +3,12 @@ package com.woowacourse.matzip.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
+import com.woowacourse.matzip.domain.member.Member;
+import com.woowacourse.matzip.domain.member.MemberRepository;
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import com.woowacourse.matzip.domain.restaurant.RestaurantRepository;
+import com.woowacourse.matzip.domain.review.Review;
+import com.woowacourse.matzip.domain.review.ReviewRepository;
 import com.woowacourse.support.SpringServiceTest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -14,6 +20,12 @@ class RestaurantServiceTest {
 
     @Autowired
     private RestaurantService restaurantService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private RestaurantRepository restaurantRepository;
+    @Autowired
+    private ReviewRepository reviewRepository;
 
     @Test
     void 캠퍼스id가_일치하는_식당_목록_페이지를_반환한다() {
@@ -29,5 +41,39 @@ class RestaurantServiceTest {
                 Pageable.ofSize(10));
 
         assertThat(responses).hasSize(2);
+    }
+
+    @Test
+    void 식당_목록_조회시_평균별점도_조회한다() {
+        Member member = Member.builder()
+                .githubId("githubId")
+                .username("username")
+                .profileImage("url")
+                .build();
+        Restaurant restaurant = Restaurant.builder()
+                .campusId(1L)
+                .categoryId(1L)
+                .name("테스트식당")
+                .address("테스트주소")
+                .kakaoMapUrl("testURL")
+                .imageUrl("testURL")
+                .build();
+        restaurantRepository.save(restaurant);
+        for (int i = 1; i <= 10; i++) {
+            reviewRepository.save(Review.builder()
+                    .member(memberRepository.save(member))
+                    .restaurantId(restaurant.getId())
+                    .content("맛있어요")
+                    .rating(4)
+                    .menu("족발" + i)
+                    .build());
+        }
+
+        List<RestaurantTitleResponse> responses = restaurantService.findByCampusIdOrderByIdDesc(1L, 1L,
+                Pageable.ofSize(10));
+
+        assertThat(responses).hasSize(1)
+                .extracting(RestaurantTitleResponse::getRating)
+                .containsExactly(4.0);
     }
 }

--- a/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
@@ -22,7 +22,7 @@ public class RestaurantRepositoryTest {
                 .campusId(1L)
                 .name("식당1")
                 .address("주소1")
-                .distance(10L)
+                .distance(10)
                 .kakaoMapUrl("www.kakao.test.com")
                 .imageUrl("www.test.com")
                 .build();
@@ -31,7 +31,7 @@ public class RestaurantRepositoryTest {
                 .campusId(1L)
                 .name("식당2")
                 .address("주소2")
-                .distance(10L)
+                .distance(10)
                 .kakaoMapUrl("www.kakao.test.com")
                 .imageUrl("www.test.com")
                 .build();
@@ -49,7 +49,7 @@ public class RestaurantRepositoryTest {
                 .campusId(1L)
                 .name("식당1")
                 .address("주소1")
-                .distance(10L)
+                .distance(10)
                 .kakaoMapUrl("www.kakao.test.com")
                 .imageUrl("www.test.com")
                 .build();
@@ -58,7 +58,7 @@ public class RestaurantRepositoryTest {
                 .campusId(1L)
                 .name("식당2")
                 .address("주소2")
-                .distance(10L)
+                .distance(10)
                 .kakaoMapUrl("www.kakao.test.com")
                 .imageUrl("www.test.com")
                 .build();
@@ -77,7 +77,7 @@ public class RestaurantRepositoryTest {
                 .campusId(1L)
                 .name("식당1")
                 .address("주소1")
-                .distance(10L)
+                .distance(10)
                 .kakaoMapUrl("www.kakao.test.com")
                 .imageUrl("www.test.com")
                 .build();
@@ -86,7 +86,7 @@ public class RestaurantRepositoryTest {
                 .campusId(1L)
                 .name("식당2")
                 .address("주소2")
-                .distance(10L)
+                .distance(10)
                 .kakaoMapUrl("www.kakao.test.com")
                 .imageUrl("www.test.com")
                 .build();
@@ -95,7 +95,7 @@ public class RestaurantRepositoryTest {
                 .campusId(1L)
                 .name("식당3")
                 .address("주소3")
-                .distance(10L)
+                .distance(10)
                 .kakaoMapUrl("www.kakao.test.com")
                 .imageUrl("www.test.com")
                 .build();
@@ -104,7 +104,7 @@ public class RestaurantRepositoryTest {
                 .campusId(1L)
                 .name("식당4")
                 .address("주소4")
-                .distance(10L)
+                .distance(10)
                 .kakaoMapUrl("www.kakao.test.com")
                 .imageUrl("www.test.com")
                 .build();

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
@@ -32,12 +32,14 @@ class ReviewRepositoryTest {
                     .member(memberRepository.save(member))
                     .restaurantId(1L)
                     .content("맛있어요")
-                    .score(4)
+                    .rating(4)
                     .menu("족발" + i)
                     .build());
         }
-        List<Review> firstReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L, PageRequest.of(0, 5));
-        List<Review> secondReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L, PageRequest.of(1, 5));
+        List<Review> firstReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L,
+                PageRequest.of(0, 5));
+        List<Review> secondReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L,
+                PageRequest.of(1, 5));
 
         assertAll(
                 () -> assertThat(firstReviewPage).hasSize(5),

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
@@ -75,7 +75,8 @@ class ReviewRepositoryTest {
                     .build());
         }
 
-        double average = reviewRepository.findAverageRatingByRestaurantId(1L);
+        double average = reviewRepository.findAverageRatingByRestaurantId(1L)
+                .orElse(0.0);
 
         assertThat(average).isEqualTo(4.5);
     }

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
@@ -48,4 +48,27 @@ class ReviewRepositoryTest {
                 () -> assertThat(secondReviewPage.get(0).getMenu()).isEqualTo("족발15")
         );
     }
+
+    @Test
+    void 전체_별점을_반환한다() {
+        Member member = Member.builder()
+                .githubId("githubId")
+                .username("username")
+                .profileImage("url")
+                .build();
+        for (int i = 1; i <= 20; i++) {
+            reviewRepository.save(Review.builder()
+                    .member(memberRepository.save(member))
+                    .restaurantId(1L)
+                    .content("맛있어요")
+                    .rating(4)
+                    .menu("족발" + i)
+                    .build());
+        }
+
+        List<Integer> ratings = reviewRepository.findRatingsByRestaurantId(1L);
+
+        assertThat(ratings).hasSize(20)
+                .containsOnly(4);
+    }
 }

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
@@ -50,13 +50,13 @@ class ReviewRepositoryTest {
     }
 
     @Test
-    void 전체_별점을_반환한다() {
+    void 평균_별점을_반환한다() {
         Member member = Member.builder()
                 .githubId("githubId")
                 .username("username")
                 .profileImage("url")
                 .build();
-        for (int i = 1; i <= 20; i++) {
+        for (int i = 1; i <= 10; i++) {
             reviewRepository.save(Review.builder()
                     .member(memberRepository.save(member))
                     .restaurantId(1L)
@@ -65,10 +65,18 @@ class ReviewRepositoryTest {
                     .menu("족발" + i)
                     .build());
         }
+        for (int i = 11; i <= 20; i++) {
+            reviewRepository.save(Review.builder()
+                    .member(memberRepository.save(member))
+                    .restaurantId(1L)
+                    .content("맛있어요")
+                    .rating(5)
+                    .menu("족발" + i)
+                    .build());
+        }
 
-        List<Integer> ratings = reviewRepository.findRatingsByRestaurantId(1L);
+        double average = reviewRepository.findAverageRatingByRestaurantId(1L);
 
-        assertThat(ratings).hasSize(20)
-                .containsOnly(4);
+        assertThat(average).isEqualTo(4.5);
     }
 }

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
@@ -11,7 +11,7 @@ public class ReviewTest {
     @ParameterizedTest
     @ValueSource(ints = {-1, 6})
     void 별점_범위제한인_경우_예외발생(final int score) {
-        assertThatThrownBy(() -> Review.builder().score(score).build())
+        assertThatThrownBy(() -> Review.builder().rating(score).build())
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage("리뷰 점수는 0점부터 5점까지만 가능합니다.");
     }


### PR DESCRIPTION
## issue: #19

## as-is
- 식당 목록 조회 시 별점 정보를 가져오지 않음
  - 별점 값 변수명 변경 필요(현재 score, rating으로 변경하기로 합의)
- 식당 목록 조회 시 너무 많은 정보를 담아줌

## to-be
- 식당 목록 조회 시 평균 별점 정보를 가져오는 기능 구현
- 별점 값의 변수명을 score -> rating으로 변경
- 식당 목록 조회 시 필요한 정보만 반환하는 dto를 추가