### PR TITLE
feat: 식당 목록, 리뷰 목록 응답 시 무한 페이징을 위한 hasNext 값을 함께 응답하는 기능 구현

### DIFF
--- a/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -2,6 +2,7 @@ package com.woowacourse.matzip.application;
 
 import com.woowacourse.matzip.application.response.RestaurantResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
+import com.woowacourse.matzip.application.response.RestaurantTitlesResponse;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
 import com.woowacourse.matzip.domain.restaurant.RestaurantRepository;
 import com.woowacourse.matzip.domain.review.ReviewRepository;
@@ -9,6 +10,7 @@ import com.woowacourse.matzip.exception.RestaurantNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,12 +26,13 @@ public class RestaurantService {
         this.reviewRepository = reviewRepository;
     }
 
-    public List<RestaurantTitleResponse> findByCampusIdOrderByIdDesc(final Long campusId, final Long categoryId,
-                                                                     final Pageable pageable) {
-        return restaurantRepository.findPageByCampusIdOrderByIdDesc(campusId, categoryId, pageable)
-                .stream()
+    public RestaurantTitlesResponse findByCampusIdOrderByIdDesc(final Long campusId, final Long categoryId,
+                                                                final Pageable pageable) {
+        Slice<Restaurant> page = restaurantRepository.findPageByCampusIdOrderByIdDesc(campusId, categoryId, pageable);
+        List<RestaurantTitleResponse> restaurantTitleResponses = page.stream()
                 .map(this::toResponseTitleResponse)
                 .collect(Collectors.toList());
+        return new RestaurantTitlesResponse(page.hasNext(), restaurantTitleResponses);
     }
 
     public List<RestaurantTitleResponse> findRandomsByCampusId(final Long campusId, final int size) {

--- a/src/main/java/com/woowacourse/matzip/application/ReviewService.java
+++ b/src/main/java/com/woowacourse/matzip/application/ReviewService.java
@@ -1,6 +1,7 @@
 package com.woowacourse.matzip.application;
 
 import com.woowacourse.matzip.application.response.ReviewResponse;
+import com.woowacourse.matzip.application.response.ReviewsResponse;
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.member.MemberRepository;
 import com.woowacourse.matzip.domain.review.Review;
@@ -10,6 +11,7 @@ import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,10 +36,11 @@ public class ReviewService {
         reviewRepository.save(review);
     }
 
-    public List<ReviewResponse> findPageByRestaurantId(final Long restaurantId, final Pageable pageable) {
-        return reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(restaurantId, pageable)
-                .stream()
+    public ReviewsResponse findPageByRestaurantId(final Long restaurantId, final Pageable pageable) {
+        Slice<Review> page = reviewRepository.findPageByRestaurantIdOrderByIdDesc(restaurantId, pageable);
+        List<ReviewResponse> reviewResponses = page.stream()
                 .map(ReviewResponse::from)
                 .collect(Collectors.toList());
+        return new ReviewsResponse(page.hasNext(), reviewResponses);
     }
 }

--- a/src/main/java/com/woowacourse/matzip/application/response/RestaurantTitlesResponse.java
+++ b/src/main/java/com/woowacourse/matzip/application/response/RestaurantTitlesResponse.java
@@ -1,0 +1,25 @@
+package com.woowacourse.matzip.application.response;
+
+import java.util.List;
+
+public class RestaurantTitlesResponse {
+
+    private boolean hasNext;
+    private List<RestaurantTitleResponse> restaurants;
+
+    private RestaurantTitlesResponse() {
+    }
+
+    public RestaurantTitlesResponse(boolean hasNext, List<RestaurantTitleResponse> restaurants) {
+        this.hasNext = hasNext;
+        this.restaurants = restaurants;
+    }
+
+    public boolean hasNext() {
+        return hasNext;
+    }
+
+    public List<RestaurantTitleResponse> getRestaurants() {
+        return restaurants;
+    }
+}

--- a/src/main/java/com/woowacourse/matzip/application/response/RestaurantTitlesResponse.java
+++ b/src/main/java/com/woowacourse/matzip/application/response/RestaurantTitlesResponse.java
@@ -1,7 +1,9 @@
 package com.woowacourse.matzip.application.response;
 
 import java.util.List;
+import lombok.Getter;
 
+@Getter
 public class RestaurantTitlesResponse {
 
     private boolean hasNext;
@@ -13,13 +15,5 @@ public class RestaurantTitlesResponse {
     public RestaurantTitlesResponse(boolean hasNext, List<RestaurantTitleResponse> restaurants) {
         this.hasNext = hasNext;
         this.restaurants = restaurants;
-    }
-
-    public boolean hasNext() {
-        return hasNext;
-    }
-
-    public List<RestaurantTitleResponse> getRestaurants() {
-        return restaurants;
     }
 }

--- a/src/main/java/com/woowacourse/matzip/application/response/ReviewsResponse.java
+++ b/src/main/java/com/woowacourse/matzip/application/response/ReviewsResponse.java
@@ -1,7 +1,9 @@
 package com.woowacourse.matzip.application.response;
 
 import java.util.List;
+import lombok.Getter;
 
+@Getter
 public class ReviewsResponse {
 
     private boolean hasNext;
@@ -13,13 +15,5 @@ public class ReviewsResponse {
     public ReviewsResponse(boolean hasNext, List<ReviewResponse> reviews) {
         this.hasNext = hasNext;
         this.reviews = reviews;
-    }
-
-    public boolean hasNext() {
-        return hasNext;
-    }
-
-    public List<ReviewResponse> getReviews() {
-        return reviews;
     }
 }

--- a/src/main/java/com/woowacourse/matzip/application/response/ReviewsResponse.java
+++ b/src/main/java/com/woowacourse/matzip/application/response/ReviewsResponse.java
@@ -1,0 +1,25 @@
+package com.woowacourse.matzip.application.response;
+
+import java.util.List;
+
+public class ReviewsResponse {
+
+    private boolean hasNext;
+    private List<ReviewResponse> reviews;
+
+    private ReviewsResponse() {
+    }
+
+    public ReviewsResponse(boolean hasNext, List<ReviewResponse> reviews) {
+        this.hasNext = hasNext;
+        this.reviews = reviews;
+    }
+
+    public boolean hasNext() {
+        return hasNext;
+    }
+
+    public List<ReviewResponse> getReviews() {
+        return reviews;
+    }
+}

--- a/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
@@ -2,6 +2,7 @@ package com.woowacourse.matzip.domain.restaurant;
 
 import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -15,7 +16,7 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
                     + "(:categoryId is null or r.categoryId = :categoryId )"
                     + "order by r.id desc"
     )
-    List<Restaurant> findPageByCampusIdOrderByIdDesc(Long campusId, Long categoryId, Pageable pageable);
+    Slice<Restaurant> findPageByCampusIdOrderByIdDesc(Long campusId, Long categoryId, Pageable pageable);
 
     @Query(
             value = "select id, category_id, campus_id, name, address, distance, kakao_map_url, image_url "

--- a/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
@@ -13,5 +13,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     )
     Optional<Double> findAverageRatingUsingRestaurantId(Long restaurantId);
 
-    Slice<Review> findReviewsByRestaurantIdOrderByIdDesc(Long restaurantId, Pageable pageable);
+    Slice<Review> findPageByRestaurantIdOrderByIdDesc(Long restaurantId, Pageable pageable);
 }

--- a/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/ReviewRepository.java
@@ -1,8 +1,8 @@
 package com.woowacourse.matzip.domain.review;
 
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -13,5 +13,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     )
     Optional<Double> findAverageRatingUsingRestaurantId(Long restaurantId);
 
-    List<Review> findReviewsByRestaurantIdOrderByIdDesc(Long restaurantId, Pageable pageable);
+    Slice<Review> findReviewsByRestaurantIdOrderByIdDesc(Long restaurantId, Pageable pageable);
 }

--- a/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
+++ b/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
@@ -3,6 +3,7 @@ package com.woowacourse.matzip.presentation;
 import com.woowacourse.matzip.application.RestaurantService;
 import com.woowacourse.matzip.application.response.RestaurantResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
+import com.woowacourse.matzip.application.response.RestaurantTitlesResponse;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -23,15 +24,15 @@ public class RestaurantController {
     }
 
     @GetMapping("/campuses/{campusId}/restaurants")
-    public ResponseEntity<List<RestaurantTitleResponse>> showPage(@PathVariable final Long campusId,
-                                                                  @RequestParam(required = false) final Long categoryId,
-                                                                  final Pageable pageable) {
+    public ResponseEntity<RestaurantTitlesResponse> showPage(@PathVariable final Long campusId,
+                                                             @RequestParam(required = false) final Long categoryId,
+                                                             final Pageable pageable) {
         return ResponseEntity.ok(restaurantService.findByCampusIdOrderByIdDesc(campusId, categoryId, pageable));
     }
 
     @GetMapping("/campuses/{campusId}/restaurants/random")
-    public ResponseEntity<List<RestaurantTitleResponse>> showRandom(@PathVariable final Long campusId,
-                                                                    @RequestParam final int size) {
+    public ResponseEntity<List<RestaurantTitleResponse>> showRandoms(@PathVariable final Long campusId,
+                                                                     @RequestParam final int size) {
         return ResponseEntity.ok(restaurantService.findRandomsByCampusId(campusId, size));
     }
 

--- a/src/main/java/com/woowacourse/matzip/presentation/ReviewController.java
+++ b/src/main/java/com/woowacourse/matzip/presentation/ReviewController.java
@@ -2,9 +2,8 @@ package com.woowacourse.matzip.presentation;
 
 import com.woowacourse.auth.support.AuthenticationPrincipal;
 import com.woowacourse.matzip.application.ReviewService;
-import com.woowacourse.matzip.application.response.ReviewResponse;
+import com.woowacourse.matzip.application.response.ReviewsResponse;
 import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,8 +33,8 @@ public class ReviewController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ReviewResponse>> findReviews(@PathVariable final Long restaurantId,
-                                                            final Pageable pageable) {
+    public ResponseEntity<ReviewsResponse> findReviews(@PathVariable final Long restaurantId,
+                                                       final Pageable pageable) {
         return ResponseEntity.ok(reviewService.findPageByRestaurantId(restaurantId, pageable));
     }
 }

--- a/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
+++ b/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
@@ -6,7 +6,7 @@ import static com.woowacourse.acceptance.support.RestAssuredRequest.httpPostRequ
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.matzip.application.response.ReviewResponse;
+import com.woowacourse.matzip.application.response.ReviewsResponse;
 import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -51,7 +51,7 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     private void 리뷰_조회에_성공한다(final ExtractableResponse<Response> response) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getList(".", ReviewResponse.class)).hasSize(5)
+                () -> assertThat(response.jsonPath().getObject(".", ReviewsResponse.class).getReviews()).hasSize(5)
         );
     }
 }

--- a/src/test/java/com/woowacourse/document/DocumentationFixture.java
+++ b/src/test/java/com/woowacourse/document/DocumentationFixture.java
@@ -4,6 +4,7 @@ import com.woowacourse.matzip.application.response.CampusResponse;
 import com.woowacourse.matzip.application.response.CategoryResponse;
 import com.woowacourse.matzip.application.response.RestaurantResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
+import com.woowacourse.matzip.application.response.RestaurantTitlesResponse;
 import com.woowacourse.matzip.application.response.ReviewResponse;
 import com.woowacourse.matzip.application.response.ReviewResponse.ReviewAuthor;
 import com.woowacourse.matzip.domain.campus.Campus;
@@ -43,15 +44,19 @@ public class DocumentationFixture {
             "서울 강남구 선릉로86길 5-4 1층", 1L,
             "https://place.map.kakao.com/18283045", "www.image.com");
 
-    public static final List<RestaurantTitleResponse> SEOLLEUNG_RESTAURANT_RESPONSES = Stream.of(SEOLLEUNG_RESTAURANT_3,
-                    SEOLLEUNG_RESTAURANT_2, SEOLLEUNG_RESTAURANT_1)
-            .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
-            .collect(Collectors.toList());
+    public static final RestaurantTitlesResponse SEOLLEUNG_RESTAURANT_RESPONSES = new RestaurantTitlesResponse(
+            false,
+            Stream.of(SEOLLEUNG_RESTAURANT_3, SEOLLEUNG_RESTAURANT_2, SEOLLEUNG_RESTAURANT_1)
+                    .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
+                    .collect(Collectors.toList())
+    );
 
-    public static final List<RestaurantTitleResponse> SEOLLEUNG_KOREAN_RESTAURANT_RESPONSES = Stream.of(
-                    SEOLLEUNG_RESTAURANT_2, SEOLLEUNG_RESTAURANT_1)
-            .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
-            .collect(Collectors.toList());
+    public static final RestaurantTitlesResponse SEOLLEUNG_KOREAN_RESTAURANT_RESPONSES = new RestaurantTitlesResponse(
+            false,
+            Stream.of(SEOLLEUNG_RESTAURANT_3, SEOLLEUNG_RESTAURANT_2)
+                    .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
+                    .collect(Collectors.toList())
+    );
 
     public static final List<RestaurantTitleResponse> SEOLLEUNG_RESTAURANT_RANDOM_2_RESPONSES = Stream.of(
                     SEOLLEUNG_RESTAURANT_1, SEOLLEUNG_RESTAURANT_3)

--- a/src/test/java/com/woowacourse/document/DocumentationFixture.java
+++ b/src/test/java/com/woowacourse/document/DocumentationFixture.java
@@ -7,6 +7,7 @@ import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitlesResponse;
 import com.woowacourse.matzip.application.response.ReviewResponse;
 import com.woowacourse.matzip.application.response.ReviewResponse.ReviewAuthor;
+import com.woowacourse.matzip.application.response.ReviewsResponse;
 import com.woowacourse.matzip.domain.campus.Campus;
 import com.woowacourse.matzip.domain.category.Category;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
@@ -77,6 +78,7 @@ public class DocumentationFixture {
     private static final ReviewResponse REVIEW_5 = new ReviewResponse(5L, new ReviewAuthor("블링", "url"), "또오고 싶어요.", 5,
             "통마늘 닭똥집볶음");
 
-    public static final List<ReviewResponse> REVIEW_RESPONSES = List.of(REVIEW_1, REVIEW_2, REVIEW_3, REVIEW_4,
-            REVIEW_5);
+    public static final ReviewsResponse REVIEW_RESPONSES = new ReviewsResponse(
+            false, List.of(REVIEW_1, REVIEW_2, REVIEW_3, REVIEW_4, REVIEW_5)
+    );
 }

--- a/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -44,11 +44,11 @@ class RestaurantServiceTest {
                 () -> assertThat(page1.getRestaurants()).hasSize(2)
                         .extracting(RestaurantTitleResponse::getName)
                         .containsExactly("마담밍", "뽕나무쟁이 선릉본점"),
-                () -> assertThat(page1.hasNext()).isTrue(),
+                () -> assertThat(page1.isHasNext()).isTrue(),
                 () -> assertThat(page2.getRestaurants()).hasSize(1)
                         .extracting(RestaurantTitleResponse::getName)
                         .containsExactly("배가무닭볶음탕"),
-                () -> assertThat(page2.hasNext()).isFalse()
+                () -> assertThat(page2.isHasNext()).isFalse()
         );
     }
 
@@ -61,7 +61,7 @@ class RestaurantServiceTest {
                 () -> assertThat(response.getRestaurants()).hasSize(2)
                         .extracting(RestaurantTitleResponse::getName)
                         .containsExactly("뽕나무쟁이 선릉본점", "배가무닭볶음탕"),
-                () -> assertThat(response.hasNext()).isFalse()
+                () -> assertThat(response.isHasNext()).isFalse()
         );
     }
 

--- a/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.matzip.application.response.RestaurantResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
+import com.woowacourse.matzip.application.response.RestaurantTitlesResponse;
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.member.MemberRepository;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
@@ -34,29 +35,34 @@ class RestaurantServiceTest {
 
     @Test
     void 캠퍼스id가_일치하는_식당_목록_페이지를_반환한다() {
-        List<RestaurantTitleResponse> page1 = restaurantService.findByCampusIdOrderByIdDesc(2L, null,
+        RestaurantTitlesResponse page1 = restaurantService.findByCampusIdOrderByIdDesc(2L, null,
                 Pageable.ofSize(2));
-        List<RestaurantTitleResponse> page2 = restaurantService.findByCampusIdOrderByIdDesc(2L, null,
+        RestaurantTitlesResponse page2 = restaurantService.findByCampusIdOrderByIdDesc(2L, null,
                 PageRequest.of(1, 2));
 
         assertAll(
-                () -> assertThat(page1).hasSize(2)
+                () -> assertThat(page1.getRestaurants()).hasSize(2)
                         .extracting(RestaurantTitleResponse::getName)
                         .containsExactly("마담밍", "뽕나무쟁이 선릉본점"),
-                () -> assertThat(page2).hasSize(1)
+                () -> assertThat(page1.hasNext()).isTrue(),
+                () -> assertThat(page2.getRestaurants()).hasSize(1)
                         .extracting(RestaurantTitleResponse::getName)
-                        .containsExactly("배가무닭볶음탕")
+                        .containsExactly("배가무닭볶음탕"),
+                () -> assertThat(page2.hasNext()).isFalse()
         );
     }
 
     @Test
     void 캠퍼스id와_카테고리id가_일치하는_식당_목록_페이지를_반환한다() {
-        List<RestaurantTitleResponse> responses = restaurantService.findByCampusIdOrderByIdDesc(2L, 1L,
+        RestaurantTitlesResponse response = restaurantService.findByCampusIdOrderByIdDesc(2L, 1L,
                 Pageable.ofSize(2));
 
-        assertThat(responses).hasSize(2)
-                .extracting(RestaurantTitleResponse::getName)
-                .containsExactly("뽕나무쟁이 선릉본점", "배가무닭볶음탕");
+        assertAll(
+                () -> assertThat(response.getRestaurants()).hasSize(2)
+                        .extracting(RestaurantTitleResponse::getName)
+                        .containsExactly("뽕나무쟁이 선릉본점", "배가무닭볶음탕"),
+                () -> assertThat(response.hasNext()).isFalse()
+        );
     }
 
     @Test
@@ -85,10 +91,10 @@ class RestaurantServiceTest {
                     .build());
         }
 
-        List<RestaurantTitleResponse> responses = restaurantService.findByCampusIdOrderByIdDesc(1L, 1L,
+        RestaurantTitlesResponse response = restaurantService.findByCampusIdOrderByIdDesc(1L, 1L,
                 Pageable.ofSize(10));
 
-        assertThat(responses).hasSize(1)
+        assertThat(response.getRestaurants()).hasSize(1)
                 .extracting(RestaurantTitleResponse::getRating)
                 .containsExactly(4.0);
     }

--- a/src/test/java/com/woowacourse/matzip/application/ReviewServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/ReviewServiceTest.java
@@ -63,9 +63,9 @@ public class ReviewServiceTest {
 
         assertAll(
                 () -> assertThat(page1.getReviews()).hasSize(2),
-                () -> assertThat(page1.hasNext()).isTrue(),
+                () -> assertThat(page1.isHasNext()).isTrue(),
                 () -> assertThat(page2.getReviews()).hasSize(1),
-                () -> assertThat(page2.hasNext()).isFalse()
+                () -> assertThat(page2.isHasNext()).isFalse()
         );
     }
 }

--- a/src/test/java/com/woowacourse/matzip/application/ReviewServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/ReviewServiceTest.java
@@ -2,9 +2,12 @@ package com.woowacourse.matzip.application;
 
 import static com.woowacourse.auth.support.GithubResponseFixtures.HUNI;
 import static com.woowacourse.matzip.support.ReviewFixtures.REVIEW_1;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.woowacourse.matzip.application.response.ReviewsResponse;
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.member.MemberRepository;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
@@ -14,6 +17,7 @@ import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
 import com.woowacourse.support.SpringServiceTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 @SpringServiceTest
 public class ReviewServiceTest {
@@ -42,6 +46,26 @@ public class ReviewServiceTest {
         Member member = memberRepository.save(HUNI.toMember());
         Restaurant restaurant = restaurantRepository.findAll().get(0);
 
-        assertDoesNotThrow(() -> reviewService.createReview(member.getGithubId(), restaurant.getId(), reviewCreateRequest()));
+        assertDoesNotThrow(
+                () -> reviewService.createReview(member.getGithubId(), restaurant.getId(), reviewCreateRequest()));
+    }
+
+    @Test
+    void 리뷰를_조회한다() {
+        Member member = memberRepository.save(HUNI.toMember());
+        Restaurant restaurant = restaurantRepository.findAll().get(0);
+        for (int i = 0; i < 3; i++) {
+            reviewService.createReview(member.getGithubId(), restaurant.getId(), reviewCreateRequest());
+        }
+
+        ReviewsResponse page1 = reviewService.findPageByRestaurantId(restaurant.getId(), PageRequest.of(0, 2));
+        ReviewsResponse page2 = reviewService.findPageByRestaurantId(restaurant.getId(), PageRequest.of(1, 2));
+
+        assertAll(
+                () -> assertThat(page1.getReviews()).hasSize(2),
+                () -> assertThat(page1.hasNext()).isTrue(),
+                () -> assertThat(page2.getReviews()).hasSize(1),
+                () -> assertThat(page2.hasNext()).isFalse()
+        );
     }
 }

--- a/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 @DataJpaTest
 public class RestaurantRepositoryTest {
@@ -23,9 +24,9 @@ public class RestaurantRepositoryTest {
         Restaurant restaurant3 = createTestRestaurant(1L, 1L, "식당3", "주소3");
         restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3));
 
-        List<Restaurant> page1 = restaurantRepository.findPageByCampusIdOrderByIdDesc(1L, null,
+        Slice<Restaurant> page1 = restaurantRepository.findPageByCampusIdOrderByIdDesc(1L, null,
                 PageRequest.of(0, 2));
-        List<Restaurant> page2 = restaurantRepository.findPageByCampusIdOrderByIdDesc(1L, null,
+        Slice<Restaurant> page2 = restaurantRepository.findPageByCampusIdOrderByIdDesc(1L, null,
                 PageRequest.of(1, 2));
 
         assertAll(
@@ -41,7 +42,7 @@ public class RestaurantRepositoryTest {
         Restaurant restaurant3 = createTestRestaurant(2L, 1L, "식당3", "주소3");
         restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3));
 
-        List<Restaurant> page1 = restaurantRepository.findPageByCampusIdOrderByIdDesc(1L, 1L,
+        Slice<Restaurant> page1 = restaurantRepository.findPageByCampusIdOrderByIdDesc(1L, 1L,
                 Pageable.ofSize(2));
 
         assertThat(page1).containsExactly(restaurant2, restaurant1);
@@ -56,7 +57,7 @@ public class RestaurantRepositoryTest {
         restaurantRepository.saveAll(
                 List.of(restaurant1, restaurant2, restaurant3, restaurant4));
 
-        List<Restaurant> actual = restaurantRepository.findPageByCampusIdOrderByIdDesc(1L, 1L,
+        Slice<Restaurant> actual = restaurantRepository.findPageByCampusIdOrderByIdDesc(1L, 1L,
                 PageRequest.of(0, 2));
 
         assertThat(actual).containsExactly(restaurant4, restaurant3);

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
@@ -5,11 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.member.MemberRepository;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 
 @DataJpaTest
 class ReviewRepositoryTest {
@@ -36,16 +36,16 @@ class ReviewRepositoryTest {
                     .menu("족발" + i)
                     .build());
         }
-        List<Review> firstReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L,
+        Slice<Review> firstReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L,
                 PageRequest.of(0, 5));
-        List<Review> secondReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L,
+        Slice<Review> secondReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L,
                 PageRequest.of(1, 5));
 
         assertAll(
                 () -> assertThat(firstReviewPage).hasSize(5),
-                () -> assertThat(firstReviewPage.get(0).getMenu()).isEqualTo("족발20"),
+                () -> assertThat(firstReviewPage.getContent().get(0).getMenu()).isEqualTo("족발20"),
                 () -> assertThat(secondReviewPage).hasSize(5),
-                () -> assertThat(secondReviewPage.get(0).getMenu()).isEqualTo("족발15")
+                () -> assertThat(secondReviewPage.getContent().get(0).getMenu()).isEqualTo("족발15")
         );
     }
 

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
@@ -36,9 +36,9 @@ class ReviewRepositoryTest {
                     .menu("족발" + i)
                     .build());
         }
-        Slice<Review> firstReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L,
+        Slice<Review> firstReviewPage = reviewRepository.findPageByRestaurantIdOrderByIdDesc(1L,
                 PageRequest.of(0, 5));
-        Slice<Review> secondReviewPage = reviewRepository.findReviewsByRestaurantIdOrderByIdDesc(1L,
+        Slice<Review> secondReviewPage = reviewRepository.findPageByRestaurantIdOrderByIdDesc(1L,
                 PageRequest.of(1, 5));
 
         assertAll(


### PR DESCRIPTION
## issue: #26

## as-is
- 무한 페이징을 위한 boolean `hasNext` 값 미구현

## to-be
- Repository에서 식당 목록 반환 시 Slice로 반환하도록 구현 완료
- Service에서 hasNext값이 들어 있는 dto 반환하도록 구현 완료
