### PR TITLE
feat: 식당 검색기능 추가

### DIFF
--- a/src/docs/asciidoc/restaurant.adoc
+++ b/src/docs/asciidoc/restaurant.adoc
@@ -13,6 +13,10 @@ operation::restaurants/list-category[snippets='http-request,http-response']
 
 operation::restaurants/list-random[snippets='http-request,http-response']
 
+=== 식당 이름 검색
+
+operation::restaurants/search[snippets='http-request,http-response']
+
 === 식당 상세 정보 조회
 
 operation::restaurants[snippets='http-request,http-response']

--- a/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -5,10 +5,12 @@ import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitlesResponse;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
 import com.woowacourse.matzip.domain.restaurant.RestaurantRepository;
+import com.woowacourse.matzip.domain.restaurant.SortCondition;
 import com.woowacourse.matzip.domain.review.ReviewRepository;
 import com.woowacourse.matzip.exception.RestaurantNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -64,5 +66,18 @@ public class RestaurantService {
                 restaurantRepository.findById(restaurantId)
                         .orElseThrow(RestaurantNotFoundException::new)
         );
+    }
+
+    public RestaurantTitlesResponse findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(final Long campusId,
+                                                                                              final String name,
+                                                                                              final Pageable pageable) {
+        Pageable pageableById = toIdDescSortPageable(pageable);
+        return toRestaurantTitlesResponse(
+                restaurantRepository.findPageByCampusIdAndNameContainingIgnoreCase(campusId, name, pageableById)
+        );
+    }
+
+    private Pageable toIdDescSortPageable(final Pageable pageable) {
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), SortCondition.DEFAULT.getValue());
     }
 }

--- a/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
@@ -37,5 +37,5 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
     )
     List<Restaurant> findRandomsByCampusId(Long campusId, int size);
 
-    List<Restaurant> findByNameContainingIgnoreCase(String name);
+    List<Restaurant> findByCampusIdAndNameContainingIgnoreCase(Long campusId, String name);
 }

--- a/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
@@ -37,5 +37,5 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
     )
     List<Restaurant> findRandomsByCampusId(Long campusId, int size);
 
-    List<Restaurant> findByCampusIdAndNameContainingIgnoreCase(Long campusId, String name);
+    Slice<Restaurant> findPageByCampusIdAndNameContainingIgnoreCase(Long campusId, String name, Pageable pageable);
 }

--- a/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
+++ b/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
@@ -36,4 +36,6 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
             nativeQuery = true
     )
     List<Restaurant> findRandomsByCampusId(Long campusId, int size);
+
+    List<Restaurant> findByNameContainingIgnoreCase(String name);
 }

--- a/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
+++ b/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
@@ -47,6 +47,14 @@ public class RestaurantController {
         return ResponseEntity.ok(restaurantService.findRandomsByCampusId(campusId, size));
     }
 
+    @GetMapping("/campuses/{campusId}/restaurants/search")
+    public ResponseEntity<RestaurantTitlesResponse> searchRestaurantsPage(@PathVariable final Long campusId,
+                                                                          @RequestParam final String name,
+                                                                          final Pageable pageable) {
+        return ResponseEntity.ok(
+                restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(campusId, name, pageable));
+    }
+
     @GetMapping("/restaurants/{restaurantId}")
     public ResponseEntity<RestaurantResponse> showRestaurant(@PathVariable final Long restaurantId) {
         return ResponseEntity.ok(restaurantService.findById(restaurantId));

--- a/src/test/java/com/woowacourse/acceptance/RestaurantAcceptanceTest.java
+++ b/src/test/java/com/woowacourse/acceptance/RestaurantAcceptanceTest.java
@@ -39,6 +39,12 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
         return httpGetRequest("/api/restaurants/" + restaurantId);
     }
 
+    private static ExtractableResponse<Response> 식당_검색_요청(final Long campusId, final int page, final int size,
+                                                          final String name) {
+        return httpGetRequest(
+                "/api/campuses/" + campusId + "/restaurants/search?page=" + page + "&size=" + size + "&name=" + name);
+    }
+
     @Test
     void 선릉캠퍼스_식당_목록의_0페이지를_조회하고_다음_페이지가_있는지_확인한다() {
         ExtractableResponse<Response> response = 캠퍼스_식당_페이지_조회_요청(선릉캠퍼스_ID, 0, 1);
@@ -47,8 +53,8 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 선릉캠퍼스_식당_목록의_0페이지를_이름_순으로_조회한다() {
-        ExtractableResponse<Response> response = 캠퍼스_식당_페이지_정렬_기준_변경해서_조회_요청(선릉캠퍼스_ID, 0, 2, "spell");
-        식당이_정렬되어_있다(response, "마담밍", "배가무닭볶음탕");
+        ExtractableResponse<Response> response = 캠퍼스_식당_페이지_정렬_기준_변경해서_조회_요청(선릉캠퍼스_ID, 1, 2, "spell");
+        식당이_정렬되어_있다(response, "마담밍3", "배가무닭볶음탕");
     }
 
     @Test
@@ -69,6 +75,12 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
         식당_조회에_성공한다(response);
     }
 
+    @Test
+    void 선릉캠퍼스_식당을_이름으로_검색한다() {
+        ExtractableResponse<Response> response = 식당_검색_요청(선릉캠퍼스_ID, 0, 2, "마담밍");
+        식당_검색에_성공한다(response, "마담밍3", "마담밍2");
+    }
+
     private void 식당_조회에_성공한다(final ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
@@ -85,6 +97,15 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.as(RestaurantTitlesResponse.class).getRestaurants()).extracting("name")
                         .containsExactly(names)
+        );
+    }
+
+    private void 식당_검색에_성공한다(final ExtractableResponse<Response> response, String... names) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(RestaurantTitlesResponse.class).getRestaurants()).extracting("name")
+                        .containsExactly(names),
+                () -> assertThat(response.as(RestaurantTitlesResponse.class).isHasNext()).isTrue()
         );
     }
 }

--- a/src/test/java/com/woowacourse/document/DocumentationFixture.java
+++ b/src/test/java/com/woowacourse/document/DocumentationFixture.java
@@ -24,7 +24,7 @@ public class DocumentationFixture {
     private static final Category CATEGORY_5 = new Category(5L, "카페/디저트");
 
     public static final List<CategoryResponse> CATEGORY_RESPONSES = Stream.of(CATEGORY_1, CATEGORY_2, CATEGORY_3,
-                    CATEGORY_4, CATEGORY_5)
+            CATEGORY_4, CATEGORY_5)
             .map(CategoryResponse::from)
             .collect(Collectors.toList());
 
@@ -44,10 +44,23 @@ public class DocumentationFixture {
     private static final Restaurant SEOLLEUNG_RESTAURANT_3 = new Restaurant(3L, 2L, 2L, "마담밍",
             "서울 강남구 선릉로86길 5-4 1층", 1L,
             "https://place.map.kakao.com/18283045", "www.image.com");
+    private static final Restaurant SEOLLEUNG_RESTAURANT_4 = new Restaurant(4L, 3L, 2L, "브라운돈까스 선릉점",
+            "서울 강남구 선릉로 520", 1L,
+            "https://place.map.kakao.com/24449739", "www.image.com");
+    private static final Restaurant SEOLLEUNG_RESTAURANT_5 = new Restaurant(5L, 3L, 2L, "윤화돈까스",
+            "서울 강남구 도곡로 221 셀라빌딩 1층", 1L,
+            "https://place.map.kakao.com/471451980", "www.image.com");
 
     public static final RestaurantTitlesResponse SEOLLEUNG_RESTAURANT_RESPONSES = new RestaurantTitlesResponse(
             false,
             Stream.of(SEOLLEUNG_RESTAURANT_3, SEOLLEUNG_RESTAURANT_2, SEOLLEUNG_RESTAURANT_1)
+                    .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
+                    .collect(Collectors.toList())
+    );
+
+    public static final RestaurantTitlesResponse SEOLLEUNG_PORT_CUTLET_RESTAURANT_RESPONSES = new RestaurantTitlesResponse(
+            false,
+            Stream.of(SEOLLEUNG_RESTAURANT_5, SEOLLEUNG_RESTAURANT_4)
                     .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
                     .collect(Collectors.toList())
     );
@@ -60,7 +73,7 @@ public class DocumentationFixture {
     );
 
     public static final List<RestaurantTitleResponse> SEOLLEUNG_RESTAURANT_RANDOM_2_RESPONSES = Stream.of(
-                    SEOLLEUNG_RESTAURANT_1, SEOLLEUNG_RESTAURANT_3)
+            SEOLLEUNG_RESTAURANT_1, SEOLLEUNG_RESTAURANT_3)
             .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
             .collect(Collectors.toList());
 

--- a/src/test/java/com/woowacourse/document/RestaurantDocumentation.java
+++ b/src/test/java/com/woowacourse/document/RestaurantDocumentation.java
@@ -1,6 +1,7 @@
 package com.woowacourse.document;
 
 import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_KOREAN_RESTAURANT_RESPONSES;
+import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_PORT_CUTLET_RESTAURANT_RESPONSES;
 import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANT_RANDOM_2_RESPONSES;
 import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANT_RESPONSES;
 import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANT_RESPONSE_1;
@@ -58,6 +59,18 @@ public class RestaurantDocumentation extends Documentation {
                 .when().get("/api/restaurants/1")
                 .then().log().all()
                 .apply(document("restaurants"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 선릉캠퍼스_식당을_이름으로_검색한다() {
+        when(restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(eq(1L), eq("돈까스"), any()))
+                .thenReturn(SEOLLEUNG_PORT_CUTLET_RESTAURANT_RESPONSES);
+
+        docsGiven
+                .when().get("/api/campuses/1/restaurants/search?name=돈까스&page=0&size=2")
+                .then().log().all()
+                .apply(document("restaurants/search"))
                 .statusCode(HttpStatus.OK.value());
     }
 }

--- a/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -130,4 +130,29 @@ class RestaurantServiceTest {
         assertThatThrownBy(() -> restaurantService.findById(Long.MAX_VALUE))
                 .isInstanceOf(RestaurantNotFoundException.class);
     }
+
+    @Test
+    void 이름이_일치하는_식당목록을_반환한다() {
+        Restaurant restaurant1 = createTestRestaurant(1L, 1L, "테스트식당1", "테스트주소1");
+        Restaurant restaurant2 = createTestRestaurant(1L, 1L, "테스트식당2", "테스트주소2");
+        Restaurant restaurant3 = createTestRestaurant(1L, 1L, "테스트식당3", "테스트주소3");
+        Restaurant restaurant4 = createTestRestaurant(1L, 1L, "테스트식당4", "테스트주소4");
+        restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3, restaurant4));
+
+        RestaurantTitlesResponse response1 = restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(1L, "테스트",
+                PageRequest.of(0, 2));
+        RestaurantTitlesResponse response2 = restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(1L, "테스트",
+                PageRequest.of(1, 2));
+
+        assertAll(
+                () -> assertThat(response1.getRestaurants()).hasSize(2)
+                        .extracting("id")
+                        .containsExactly(restaurant4.getId(), restaurant3.getId()),
+                () -> assertThat(response1.isHasNext()).isTrue(),
+                () -> assertThat(response2.getRestaurants()).hasSize(2)
+                        .extracting("id")
+                        .containsExactly(restaurant2.getId(), restaurant1.getId()),
+                () -> assertThat(response2.isHasNext()).isFalse()
+        );
+    }
 }

--- a/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -45,12 +45,12 @@ class RestaurantServiceTest {
         assertAll(
                 () -> assertThat(page1.getRestaurants()).hasSize(2)
                         .extracting(RestaurantTitleResponse::getName)
-                        .containsExactly("마담밍", "뽕나무쟁이 선릉본점"),
+                        .containsExactly("마담밍3", "마담밍2"),
                 () -> assertThat(page1.isHasNext()).isTrue(),
-                () -> assertThat(page2.getRestaurants()).hasSize(1)
+                () -> assertThat(page2.getRestaurants()).hasSize(2)
                         .extracting(RestaurantTitleResponse::getName)
-                        .containsExactly("배가무닭볶음탕"),
-                () -> assertThat(page2.isHasNext()).isFalse()
+                        .containsExactly("마담밍", "뽕나무쟁이 선릉본점"),
+                () -> assertThat(page2.isHasNext()).isTrue()
         );
     }
 
@@ -111,7 +111,7 @@ class RestaurantServiceTest {
 
         assertThat(responses).hasSize(2)
                 .extracting("name")
-                .containsAnyOf("마담밍", "뽕나무쟁이 선릉본점", "배가무닭볶음탕");
+                .containsAnyOf("마담밍", "마담밍2", "마담밍3", "뽕나무쟁이 선릉본점", "배가무닭볶음탕");
     }
 
     @Test

--- a/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
@@ -124,4 +124,18 @@ public class RestaurantRepositoryTest {
         assertThat(restaurants).hasSize(2)
                 .containsAnyOf(restaurant1, restaurant2, restaurant3, restaurant4);
     }
+
+    @Test
+    void 이름이_일치하는_레스토랑을_조회한다() {
+        Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당sigdang 1", "주소1");
+        Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당SigDang 2", "주소2");
+        Restaurant restaurant3 = createTestRestaurant(1L, 1L, "당식3", "주소3");
+        Restaurant restaurant4 = createTestRestaurant(1L, 1L, "당식4", "주소4");
+        restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3, restaurant4));
+
+        List<Restaurant> restaurants = restaurantRepository.findByNameContainingIgnoreCase("식당sigdang");
+
+        assertThat(restaurants).hasSize(2)
+                .containsAnyOf(restaurant1, restaurant2);
+    }
 }

--- a/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
@@ -129,11 +129,11 @@ public class RestaurantRepositoryTest {
     void 이름이_일치하는_레스토랑을_조회한다() {
         Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당sigdang 1", "주소1");
         Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당SigDang 2", "주소2");
-        Restaurant restaurant3 = createTestRestaurant(1L, 1L, "당식3", "주소3");
+        Restaurant restaurant3 = createTestRestaurant(1L, 2L, "식당sigdang 3", "주소3");
         Restaurant restaurant4 = createTestRestaurant(1L, 1L, "당식4", "주소4");
         restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3, restaurant4));
 
-        List<Restaurant> restaurants = restaurantRepository.findByNameContainingIgnoreCase("식당sigdang");
+        List<Restaurant> restaurants = restaurantRepository.findByCampusIdAndNameContainingIgnoreCase(1L, "식당sigdang");
 
         assertThat(restaurants).hasSize(2)
                 .containsAnyOf(restaurant1, restaurant2);

--- a/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
@@ -129,13 +129,17 @@ public class RestaurantRepositoryTest {
     void 이름이_일치하는_레스토랑을_조회한다() {
         Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당sigdang 1", "주소1");
         Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당SigDang 2", "주소2");
-        Restaurant restaurant3 = createTestRestaurant(1L, 2L, "식당sigdang 3", "주소3");
-        Restaurant restaurant4 = createTestRestaurant(1L, 1L, "당식4", "주소4");
-        restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3, restaurant4));
+        Restaurant restaurant3 = createTestRestaurant(1L, 2L, "식당SigDang 3", "주소3");
+        Restaurant restaurant4 = createTestRestaurant(1L, 1L, "식당SigDang 4", "주소4");
+        Restaurant restaurant5 = createTestRestaurant(1L, 1L, "식당sigdang 5", "주소5");
+        Restaurant restaurant6 = createTestRestaurant(1L, 1L, "당식4", "주소6");
+        restaurantRepository.saveAll(
+                List.of(restaurant1, restaurant2, restaurant3, restaurant4, restaurant5, restaurant6));
 
-        List<Restaurant> restaurants = restaurantRepository.findByCampusIdAndNameContainingIgnoreCase(1L, "식당sigdang");
+        Slice<Restaurant> restaurants = restaurantRepository
+                .findPageByCampusIdAndNameContainingIgnoreCase(1L, "식당sigdang", PageRequest.of(1, 2));
 
         assertThat(restaurants).hasSize(2)
-                .containsAnyOf(restaurant1, restaurant2);
+                .containsAnyOf(restaurant4, restaurant5);
     }
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -20,3 +20,7 @@ insert into restaurant (category_id, campus_id, name, address, distance, kakao_m
 values (1, 2, '뽕나무쟁이 선릉본점', '서울 강남구 역삼로65길 31', 1, 'https://place.map.kakao.com/11190567', 'www.image.com');
 insert into restaurant (category_id, campus_id, name, address, distance, kakao_map_url, image_url)
 values (2, 2, '마담밍', '서울 강남구 선릉로86길 5-4 1층', 1, 'https://place.map.kakao.com/18283045', 'www.image.com');
+insert into restaurant (category_id, campus_id, name, address, distance, kakao_map_url, image_url)
+values (2, 2, '마담밍2', '서울 강남구 선릉로86길 5-4 2층', 1, 'https://place.map.kakao.com/18283045', 'www.image.com');
+insert into restaurant (category_id, campus_id, name, address, distance, kakao_map_url, image_url)
+values (2, 2, '마담밍3', '서울 강남구 선릉로86길 5-4 3층', 1, 'https://place.map.kakao.com/18283045', 'www.image.com');


### PR DESCRIPTION
## issue: #32 

## as-is
- 식당 검색 api 미구현
- 식당 검색 쿼리 미구현

## to-be
- `findPageByCampusIdAndNameContainingIgnoreCase()` 식당 검색 쿼리 추가
- `GET /campuses/{campusId}/restaurants/search` name, page, size param api 추가
