### PR TITLE
feat: 식당 상세 목록 조회 시 평균 별점도 함께 조회하는 기능 구현, 누락된 테스트 추가

### DIFF
--- a/src/docs/asciidoc/restaurant.adoc
+++ b/src/docs/asciidoc/restaurant.adoc
@@ -5,6 +5,14 @@
 
 operation::restaurants/list[snippets='http-request,http-response']
 
+=== 캠퍼스 별 식당 목록 가나다순 조회
+
+operation::restaurants/list-spell[snippets='http-request,http-response']
+
+=== 캠퍼스 별 식당 목록 별점순 조회
+
+operation::restaurants/list-rating[snippets='http-request,http-response']
+
 === 캠퍼스 별 카테고리가 일치하는 식당 목록 조회
 
 operation::restaurants/list-category[snippets='http-request,http-response']

--- a/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -62,9 +62,11 @@ public class RestaurantService {
     }
 
     public RestaurantResponse findById(final Long restaurantId) {
-        return RestaurantResponse.from(
+        return RestaurantResponse.of(
                 restaurantRepository.findById(restaurantId)
-                        .orElseThrow(RestaurantNotFoundException::new)
+                        .orElseThrow(RestaurantNotFoundException::new),
+                reviewRepository.findAverageRatingUsingRestaurantId(restaurantId)
+                        .orElse(0.0)
         );
     }
 

--- a/src/main/java/com/woowacourse/matzip/application/response/RestaurantResponse.java
+++ b/src/main/java/com/woowacourse/matzip/application/response/RestaurantResponse.java
@@ -10,6 +10,7 @@ public class RestaurantResponse {
     private String name;
     private String address;
     private long distance;
+    private double rating;
     private String kakaoMapUrl;
     private String imageUrl;
 
@@ -17,20 +18,22 @@ public class RestaurantResponse {
     }
 
     private RestaurantResponse(final Long id, final String name, final String address, final long distance,
-                               final String kakaoMapUrl, final String imageUrl) {
+                               final double rating, final String kakaoMapUrl, final String imageUrl) {
         this.id = id;
         this.name = name;
         this.address = address;
         this.distance = distance;
+        this.rating = rating;
         this.kakaoMapUrl = kakaoMapUrl;
         this.imageUrl = imageUrl;
     }
 
-    public static RestaurantResponse from(final Restaurant restaurant) {
+    public static RestaurantResponse of(final Restaurant restaurant, final double rating) {
         return new RestaurantResponse(restaurant.getId(),
                 restaurant.getName(),
                 restaurant.getAddress(),
                 restaurant.getDistance(),
+                rating,
                 restaurant.getKakaoMapUrl(),
                 restaurant.getImageUrl());
     }

--- a/src/main/java/com/woowacourse/matzip/application/response/RestaurantTitleResponse.java
+++ b/src/main/java/com/woowacourse/matzip/application/response/RestaurantTitleResponse.java
@@ -23,8 +23,12 @@ public class RestaurantTitleResponse {
         this.imageUrl = imageUrl;
     }
 
-    public static RestaurantTitleResponse of(Restaurant restaurant, double rating) {
-        return new RestaurantTitleResponse(restaurant.getId(), restaurant.getName(), restaurant.getDistance(), rating,
-                restaurant.getImageUrl());
+    public static RestaurantTitleResponse of(final Restaurant restaurant, final double rating) {
+        return new RestaurantTitleResponse(restaurant.getId(),
+                restaurant.getName(),
+                restaurant.getDistance(),
+                rating,
+                restaurant.getImageUrl()
+        );
     }
 }

--- a/src/test/java/com/woowacourse/document/DocumentationFixture.java
+++ b/src/test/java/com/woowacourse/document/DocumentationFixture.java
@@ -24,7 +24,7 @@ public class DocumentationFixture {
     private static final Category CATEGORY_5 = new Category(5L, "카페/디저트");
 
     public static final List<CategoryResponse> CATEGORY_RESPONSES = Stream.of(CATEGORY_1, CATEGORY_2, CATEGORY_3,
-            CATEGORY_4, CATEGORY_5)
+                    CATEGORY_4, CATEGORY_5)
             .map(CategoryResponse::from)
             .collect(Collectors.toList());
 
@@ -73,12 +73,12 @@ public class DocumentationFixture {
     );
 
     public static final List<RestaurantTitleResponse> SEOLLEUNG_RESTAURANT_RANDOM_2_RESPONSES = Stream.of(
-            SEOLLEUNG_RESTAURANT_1, SEOLLEUNG_RESTAURANT_3)
+                    SEOLLEUNG_RESTAURANT_1, SEOLLEUNG_RESTAURANT_3)
             .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
             .collect(Collectors.toList());
 
-    public static final RestaurantResponse SEOLLEUNG_RESTAURANT_RESPONSE_1 = RestaurantResponse.from(
-            SEOLLEUNG_RESTAURANT_1);
+    public static final RestaurantResponse SEOLLEUNG_RESTAURANT_RESPONSE_1 = RestaurantResponse.of(
+            SEOLLEUNG_RESTAURANT_1, 4.0);
 
     private static final ReviewResponse REVIEW_1 = new ReviewResponse(1L, new ReviewAuthor("후니", "url"), "무가 맛있어요", 5,
             "무닭볶음탕 (중)");

--- a/src/test/java/com/woowacourse/document/DocumentationFixture.java
+++ b/src/test/java/com/woowacourse/document/DocumentationFixture.java
@@ -51,28 +51,48 @@ public class DocumentationFixture {
             "서울 강남구 도곡로 221 셀라빌딩 1층", 1L,
             "https://place.map.kakao.com/471451980", "www.image.com");
 
-    public static final RestaurantTitlesResponse SEOLLEUNG_RESTAURANT_RESPONSES = new RestaurantTitlesResponse(
+    public static final RestaurantTitlesResponse SEOLLEUNG_RESTAURANTS_RESPONSE = new RestaurantTitlesResponse(
             false,
-            Stream.of(SEOLLEUNG_RESTAURANT_3, SEOLLEUNG_RESTAURANT_2, SEOLLEUNG_RESTAURANT_1)
+            Stream.of(SEOLLEUNG_RESTAURANT_5, SEOLLEUNG_RESTAURANT_4, SEOLLEUNG_RESTAURANT_3, SEOLLEUNG_RESTAURANT_2,
+                            SEOLLEUNG_RESTAURANT_1)
                     .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
                     .collect(Collectors.toList())
     );
 
-    public static final RestaurantTitlesResponse SEOLLEUNG_PORT_CUTLET_RESTAURANT_RESPONSES = new RestaurantTitlesResponse(
+    public static final RestaurantTitlesResponse SEOLLEUNG_RESTAURANTS_SORT_BY_SPELL_RESPONSE = new RestaurantTitlesResponse(
+            false,
+            Stream.of(SEOLLEUNG_RESTAURANT_3, SEOLLEUNG_RESTAURANT_1, SEOLLEUNG_RESTAURANT_4, SEOLLEUNG_RESTAURANT_2,
+                            SEOLLEUNG_RESTAURANT_5)
+                    .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
+                    .collect(Collectors.toList())
+    );
+
+    public static final RestaurantTitlesResponse SEOLLEUNG_RESTAURANTS_SORT_BY_RATING_RESPONSE = new RestaurantTitlesResponse(
+            false,
+            List.of(
+                    RestaurantTitleResponse.of(SEOLLEUNG_RESTAURANT_1, 5),
+                    RestaurantTitleResponse.of(SEOLLEUNG_RESTAURANT_2, 4.7),
+                    RestaurantTitleResponse.of(SEOLLEUNG_RESTAURANT_3, 4.2),
+                    RestaurantTitleResponse.of(SEOLLEUNG_RESTAURANT_4, 3.7),
+                    RestaurantTitleResponse.of(SEOLLEUNG_RESTAURANT_5, 3.0)
+            )
+    );
+
+    public static final RestaurantTitlesResponse SEOLLEUNG_PORT_CUTLET_RESTAURANTS_RESPONSE = new RestaurantTitlesResponse(
             false,
             Stream.of(SEOLLEUNG_RESTAURANT_5, SEOLLEUNG_RESTAURANT_4)
                     .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
                     .collect(Collectors.toList())
     );
 
-    public static final RestaurantTitlesResponse SEOLLEUNG_KOREAN_RESTAURANT_RESPONSES = new RestaurantTitlesResponse(
+    public static final RestaurantTitlesResponse SEOLLEUNG_KOREAN_RESTAURANTS_RESPONSE = new RestaurantTitlesResponse(
             false,
             Stream.of(SEOLLEUNG_RESTAURANT_3, SEOLLEUNG_RESTAURANT_2)
                     .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
                     .collect(Collectors.toList())
     );
 
-    public static final List<RestaurantTitleResponse> SEOLLEUNG_RESTAURANT_RANDOM_2_RESPONSES = Stream.of(
+    public static final List<RestaurantTitleResponse> SEOLLEUNG_RESTAURANTS_RANDOM_2_RESPONSE = Stream.of(
                     SEOLLEUNG_RESTAURANT_1, SEOLLEUNG_RESTAURANT_3)
             .map(restaurant -> RestaurantTitleResponse.of(restaurant, 4))
             .collect(Collectors.toList());
@@ -91,7 +111,7 @@ public class DocumentationFixture {
     private static final ReviewResponse REVIEW_5 = new ReviewResponse(5L, new ReviewAuthor("블링", "url"), "또오고 싶어요.", 5,
             "통마늘 닭똥집볶음");
 
-    public static final ReviewsResponse REVIEW_RESPONSES = new ReviewsResponse(
+    public static final ReviewsResponse REVIEWS_RESPONSE = new ReviewsResponse(
             false, List.of(REVIEW_1, REVIEW_2, REVIEW_3, REVIEW_4, REVIEW_5)
     );
 }

--- a/src/test/java/com/woowacourse/document/RestaurantDocumentation.java
+++ b/src/test/java/com/woowacourse/document/RestaurantDocumentation.java
@@ -1,9 +1,11 @@
 package com.woowacourse.document;
 
-import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_KOREAN_RESTAURANT_RESPONSES;
-import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_PORT_CUTLET_RESTAURANT_RESPONSES;
-import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANT_RANDOM_2_RESPONSES;
-import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANT_RESPONSES;
+import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_KOREAN_RESTAURANTS_RESPONSE;
+import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_PORT_CUTLET_RESTAURANTS_RESPONSE;
+import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANTS_RANDOM_2_RESPONSE;
+import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANTS_RESPONSE;
+import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANTS_SORT_BY_RATING_RESPONSE;
+import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANTS_SORT_BY_SPELL_RESPONSE;
 import static com.woowacourse.document.DocumentationFixture.SEOLLEUNG_RESTAURANT_RESPONSE_1;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,9 +18,9 @@ import org.springframework.http.HttpStatus;
 public class RestaurantDocumentation extends Documentation {
 
     @Test
-    void 선릉캠퍼스_식당_목록의_0페이지를_조회한다() {
+    void 선릉캠퍼스_식당_목록의_0페이지를_최신순으로_조회한다() {
         when(restaurantService.findByCampusId(eq(2L), eq(null), any())).thenReturn(
-                SEOLLEUNG_RESTAURANT_RESPONSES);
+                SEOLLEUNG_RESTAURANTS_RESPONSE);
 
         docsGiven
                 .when().get("/api/campuses/2/restaurants?page=0&size=10")
@@ -28,9 +30,33 @@ public class RestaurantDocumentation extends Documentation {
     }
 
     @Test
-    void 선릉캠퍼스_한식_식당_목록의_0페이지를_조회한다() {
+    void 선릉캠퍼스_식당_목록의_0페이지를_가나다순으로_조회한다() {
+        when(restaurantService.findByCampusId(eq(2L), eq(null), any())).thenReturn(
+                SEOLLEUNG_RESTAURANTS_SORT_BY_SPELL_RESPONSE);
+
+        docsGiven
+                .when().get("/api/campuses/2/restaurants?filter=spell&page=0&size=10")
+                .then().log().all()
+                .apply(document("restaurants/list-spell"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 선릉캠퍼스_식당_목록의_0페이지를_별점순으로_조회한다() {
+        when(restaurantService.findByCampusIdOrderByRatingDesc(eq(2L), eq(null), any())).thenReturn(
+                SEOLLEUNG_RESTAURANTS_SORT_BY_RATING_RESPONSE);
+
+        docsGiven
+                .when().get("/api/campuses/2/restaurants?filter=rating&page=0&size=10")
+                .then().log().all()
+                .apply(document("restaurants/list-rating"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 선릉캠퍼스_한식_식당_목록의_0페이지를_최신순으로_조회한다() {
         when(restaurantService.findByCampusId(eq(2L), eq(1L), any())).thenReturn(
-                SEOLLEUNG_KOREAN_RESTAURANT_RESPONSES);
+                SEOLLEUNG_KOREAN_RESTAURANTS_RESPONSE);
 
         docsGiven
                 .when().get("/api/campuses/2/restaurants?categoryId=1&page=0&size=10")
@@ -42,7 +68,7 @@ public class RestaurantDocumentation extends Documentation {
     @Test
     void 선릉캠퍼스_식당_목록을_2개_무작위로_조회한다() {
         when(restaurantService.findRandomsByCampusId(eq(2L), eq(2))).thenReturn(
-                SEOLLEUNG_RESTAURANT_RANDOM_2_RESPONSES);
+                SEOLLEUNG_RESTAURANTS_RANDOM_2_RESPONSE);
 
         docsGiven
                 .when().get("/api/campuses/2/restaurants/random?size=2")
@@ -65,7 +91,7 @@ public class RestaurantDocumentation extends Documentation {
     @Test
     void 선릉캠퍼스_식당을_이름으로_검색한다() {
         when(restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(eq(1L), eq("돈까스"), any()))
-                .thenReturn(SEOLLEUNG_PORT_CUTLET_RESTAURANT_RESPONSES);
+                .thenReturn(SEOLLEUNG_PORT_CUTLET_RESTAURANTS_RESPONSE);
 
         docsGiven
                 .when().get("/api/campuses/1/restaurants/search?name=돈까스&page=0&size=2")

--- a/src/test/java/com/woowacourse/document/ReviewDocumentation.java
+++ b/src/test/java/com/woowacourse/document/ReviewDocumentation.java
@@ -1,6 +1,6 @@
 package com.woowacourse.document;
 
-import static com.woowacourse.document.DocumentationFixture.REVIEW_RESPONSES;
+import static com.woowacourse.document.DocumentationFixture.REVIEWS_RESPONSE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -31,7 +31,7 @@ public class ReviewDocumentation extends Documentation {
 
     @Test
     void 리뷰를_조회한다() {
-        when(reviewService.findPageByRestaurantId(any(), any())).thenReturn(REVIEW_RESPONSES);
+        when(reviewService.findPageByRestaurantId(any(), any())).thenReturn(REVIEWS_RESPONSE);
 
         docsGiven
                 .when().get("/api/restaurants/1/reviews?page=0&size=5")

--- a/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.matzip.application;
 
 import static com.woowacourse.matzip.domain.restaurant.SortCondition.DEFAULT;
+import static com.woowacourse.matzip.domain.restaurant.SortCondition.SPELL;
 import static com.woowacourse.matzip.support.TestFixtureCreateUtil.createTestMember;
 import static com.woowacourse.matzip.support.TestFixtureCreateUtil.createTestRestaurant;
 import static com.woowacourse.matzip.support.TestFixtureCreateUtil.createTestReview;
@@ -36,7 +37,7 @@ class RestaurantServiceTest {
     private ReviewRepository reviewRepository;
 
     @Test
-    void 캠퍼스id가_일치하는_식당_목록_페이지를_반환한다() {
+    void 캠퍼스id가_일치하는_식당_목록_페이지를_최신순으로_반환한다() {
         RestaurantTitlesResponse page1 = restaurantService.findByCampusId(2L, null,
                 PageRequest.of(0, 2, DEFAULT.getValue()));
         RestaurantTitlesResponse page2 = restaurantService.findByCampusId(2L, null,
@@ -86,7 +87,22 @@ class RestaurantServiceTest {
     }
 
     @Test
-    void 캠퍼스id가_일치하는_식당_목록을_평균_별점_순으로_정렬한_페이지를_반환한다() {
+    void 캠퍼스id가_일치하는_식당_목록을_가나다순으로_정렬한_페이지를_반환한다() {
+        Restaurant restaurant1 = createTestRestaurant(1L, 1L, "가식당", "테스트주소1");
+        Restaurant restaurant2 = createTestRestaurant(1L, 1L, "다식당", "테스트주소2");
+        Restaurant restaurant3 = createTestRestaurant(1L, 1L, "나식당", "테스트주소3");
+        restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3));
+
+        RestaurantTitlesResponse response = restaurantService.findByCampusIdOrderByRatingDesc(1L, 1L,
+                PageRequest.of(0, 3, SPELL.getValue()));
+
+        assertThat(response.getRestaurants()).hasSize(3)
+                .extracting("id")
+                .containsExactly(restaurant1.getId(), restaurant3.getId(), restaurant2.getId());
+    }
+
+    @Test
+    void 캠퍼스id가_일치하는_식당_목록을_평균_별점순으로_정렬한_페이지를_반환한다() {
         Member member = createTestMember();
         memberRepository.save(member);
         Restaurant restaurant1 = createTestRestaurant(1L, 1L, "테스트식당1", "테스트주소1");

--- a/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -121,8 +121,12 @@ class RestaurantServiceTest {
 
         RestaurantResponse response = restaurantService.findById(restaurant.getId());
 
-        assertThat(response).usingRecursiveComparison()
-                .isEqualTo(restaurant);
+        assertAll(
+                () -> assertThat(response).usingRecursiveComparison()
+                        .ignoringFields("rating")
+                        .isEqualTo(restaurant),
+                () -> assertThat(response.getRating()).isEqualTo(0.0)
+        );
     }
 
     @Test
@@ -139,9 +143,11 @@ class RestaurantServiceTest {
         Restaurant restaurant4 = createTestRestaurant(1L, 1L, "테스트식당4", "테스트주소4");
         restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3, restaurant4));
 
-        RestaurantTitlesResponse response1 = restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(1L, "테스트",
+        RestaurantTitlesResponse response1 = restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(
+                1L, "테스트",
                 PageRequest.of(0, 2));
-        RestaurantTitlesResponse response2 = restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(1L, "테스트",
+        RestaurantTitlesResponse response2 = restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(
+                1L, "테스트",
                 PageRequest.of(1, 2));
 
         assertAll(


### PR DESCRIPTION
## issue: #34, #35

## as-is
- 식당 상세 조회 시 평균 별점 정보 조회 미구현
- 가나다순 식당 조회 Service 테스트 미구현
- 별점순 / 가나다순 식당 조회 documentation 미구현

## to-be
- 식당 상세 조회 시 평균 별점 정보를 담도록 구현 완료
- 가나다순 식당 조회 Service 테스트 구현 완료
- 별점순 / 가나다순 식당 조회 docs 구현 완료
