### PR TITLE
feat: 도메인별 validation 로직을 추가한다.

### DIFF
--- a/src/main/java/com/woowacourse/matzip/domain/campus/Campus.java
+++ b/src/main/java/com/woowacourse/matzip/domain/campus/Campus.java
@@ -1,5 +1,6 @@
 package com.woowacourse.matzip.domain.campus;
 
+import com.woowacourse.matzip.support.LengthValidator;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,11 +16,13 @@ import lombok.Getter;
 @Getter
 public class Campus {
 
+    private static final int MAX_NAME_LENGTH = 20;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", length = 20, nullable = false, unique = true)
+    @Column(name = "name", length = MAX_NAME_LENGTH, nullable = false, unique = true)
     private String name;
 
     protected Campus() {
@@ -27,6 +30,7 @@ public class Campus {
 
     @Builder
     public Campus(final Long id, final String name) {
+        LengthValidator.checkStringLength(name, MAX_NAME_LENGTH, "캠퍼스 이름");
         this.id = id;
         this.name = name;
     }

--- a/src/main/java/com/woowacourse/matzip/domain/category/Category.java
+++ b/src/main/java/com/woowacourse/matzip/domain/category/Category.java
@@ -1,6 +1,6 @@
 package com.woowacourse.matzip.domain.category;
 
-import com.woowacourse.matzip.exception.InvalidCategoryException;
+import com.woowacourse.matzip.support.LengthValidator;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -22,7 +22,7 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", length = 10, nullable = false, unique = true)
+    @Column(name = "name", length = CATEGORY_NAME_LIMIT_LENGTH, nullable = false, unique = true)
     private String name;
 
     protected Category() {
@@ -30,15 +30,9 @@ public class Category {
 
     @Builder
     public Category(final Long id, final String name) {
-        checkCategoryLength(name);
+        LengthValidator.checkStringLength(name, CATEGORY_NAME_LIMIT_LENGTH, "카테고리의 이름");
         this.id = id;
         this.name = name;
-    }
-
-    private void checkCategoryLength(final String name) {
-        if (name.length() > CATEGORY_NAME_LIMIT_LENGTH) {
-            throw new InvalidCategoryException(String.format("카테고리의 이름은 %d자를 넘을 수 없습니다.", CATEGORY_NAME_LIMIT_LENGTH));
-        }
     }
 
     @Override

--- a/src/main/java/com/woowacourse/matzip/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/woowacourse/matzip/domain/restaurant/Restaurant.java
@@ -1,5 +1,6 @@
 package com.woowacourse.matzip.domain.restaurant;
 
+import com.woowacourse.matzip.support.LengthValidator;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,6 +16,8 @@ import lombok.Getter;
 @Getter
 public class Restaurant {
 
+    private static final int MAX_NAME_LENGTH = 20;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,7 +28,7 @@ public class Restaurant {
     @Column(name = "campus_id", nullable = false)
     private Long campusId;
 
-    @Column(name = "name", length = 20, nullable = false)
+    @Column(name = "name", length = MAX_NAME_LENGTH, nullable = false)
     private String name;
 
     @Column(name = "address", nullable = false, unique = true)
@@ -46,6 +49,7 @@ public class Restaurant {
     @Builder
     public Restaurant(final Long id, final Long categoryId, final Long campusId, final String name,
                       final String address, final long distance, final String kakaoMapUrl, final String imageUrl) {
+        LengthValidator.checkStringLength(name, MAX_NAME_LENGTH, "식당 이름");
         this.id = id;
         this.categoryId = categoryId;
         this.campusId = campusId;

--- a/src/main/java/com/woowacourse/matzip/domain/review/Review.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/Review.java
@@ -21,7 +21,7 @@ import lombok.Getter;
 @Getter
 public class Review {
 
-    private static final int MIN_SCORE = 0;
+    private static final int MIN_SCORE = 1;
     private static final int MAX_SCORE = 5;
     private static final int MAX_MENU_LENGTH = 20;
     private static final int MAX_CONTENT_LENGTH = 255;
@@ -65,7 +65,7 @@ public class Review {
 
     private void validateRating(final int rating) {
         if (rating < MIN_SCORE || rating > MAX_SCORE) {
-            throw new InvalidReviewException("리뷰 점수는 0점부터 5점까지만 가능합니다.");
+            throw new InvalidReviewException(String.format("리뷰 점수는 %d점부터 %d점까지만 가능합니다.", MIN_SCORE, MAX_SCORE));
         }
     }
 

--- a/src/main/java/com/woowacourse/matzip/domain/review/Review.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/Review.java
@@ -24,6 +24,7 @@ public class Review {
     private static final int MIN_SCORE = 0;
     private static final int MAX_SCORE = 5;
     private static final int MAX_MENU_LENGTH = 20;
+    private static final int MAX_CONTENT_LENGTH = 255;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,7 +37,7 @@ public class Review {
     @Column(name = "restaurant_id", nullable = false)
     private Long restaurantId;
 
-    @Column(name = "content", length = 255)
+    @Column(name = "content", length = MAX_CONTENT_LENGTH)
     private String content;
 
     @Column(name = "rating", nullable = false)
@@ -53,6 +54,7 @@ public class Review {
                   final String menu) {
         validateRating(rating);
         LengthValidator.checkStringLength(menu, MAX_MENU_LENGTH, "메뉴의 이름");
+        LengthValidator.checkStringLength(content, MAX_CONTENT_LENGTH, "리뷰 내용");
         this.id = id;
         this.member = member;
         this.restaurantId = restaurantId;

--- a/src/main/java/com/woowacourse/matzip/domain/review/Review.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/Review.java
@@ -43,7 +43,7 @@ public class Review {
     @Column(name = "rating", nullable = false)
     private int rating;
 
-    @Column(name = "menu", length = 20, nullable = false)
+    @Column(name = "menu", length = MAX_MENU_LENGTH, nullable = false)
     private String menu;
 
     protected Review() {

--- a/src/main/java/com/woowacourse/matzip/domain/review/Review.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/Review.java
@@ -2,6 +2,7 @@ package com.woowacourse.matzip.domain.review;
 
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.exception.InvalidReviewException;
+import com.woowacourse.matzip.support.LengthValidator;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -22,6 +23,7 @@ public class Review {
 
     private static final int MIN_SCORE = 0;
     private static final int MAX_SCORE = 5;
+    private static final int MAX_MENU_LENGTH = 20;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,7 +36,7 @@ public class Review {
     @Column(name = "restaurant_id", nullable = false)
     private Long restaurantId;
 
-    @Column(name = "content")
+    @Column(name = "content", length = 255)
     private String content;
 
     @Column(name = "rating", nullable = false)
@@ -50,6 +52,7 @@ public class Review {
     public Review(final Long id, final Member member, final Long restaurantId, final String content, final int rating,
                   final String menu) {
         validateRating(rating);
+        LengthValidator.checkStringLength(menu, MAX_MENU_LENGTH, "메뉴의 이름");
         this.id = id;
         this.member = member;
         this.restaurantId = restaurantId;

--- a/src/main/java/com/woowacourse/matzip/exception/InvalidLengthException.java
+++ b/src/main/java/com/woowacourse/matzip/exception/InvalidLengthException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.matzip.exception;
+
+public class InvalidLengthException extends RuntimeException {
+
+    public InvalidLengthException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/woowacourse/matzip/presentation/ReviewController.java
+++ b/src/main/java/com/woowacourse/matzip/presentation/ReviewController.java
@@ -4,6 +4,7 @@ import com.woowacourse.auth.support.AuthenticationPrincipal;
 import com.woowacourse.matzip.application.ReviewService;
 import com.woowacourse.matzip.application.response.ReviewsResponse;
 import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
+import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +27,7 @@ public class ReviewController {
 
     @PostMapping
     public ResponseEntity<Void> createReview(@PathVariable final Long restaurantId,
-                                             @RequestBody final ReviewCreateRequest reviewCreateRequest,
+                                             @RequestBody @Valid final ReviewCreateRequest reviewCreateRequest,
                                              @AuthenticationPrincipal final String githubId) {
         reviewService.createReview(githubId, restaurantId, reviewCreateRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/woowacourse/matzip/presentation/request/ReviewCreateRequest.java
+++ b/src/main/java/com/woowacourse/matzip/presentation/request/ReviewCreateRequest.java
@@ -2,11 +2,14 @@ package com.woowacourse.matzip.presentation.request;
 
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.review.Review;
+import javax.validation.constraints.NotNull;
 
 public class ReviewCreateRequest {
 
+    @NotNull(message = "리뷰 내용은 null이 들어올 수 없습니다.")
     private String content;
     private int rating;
+    @NotNull(message = "리뷰 메뉴는 null이 들어올 수 없습니다.")
     private String menu;
 
     private ReviewCreateRequest() {

--- a/src/main/java/com/woowacourse/matzip/support/LengthValidator.java
+++ b/src/main/java/com/woowacourse/matzip/support/LengthValidator.java
@@ -10,13 +10,13 @@ public class LengthValidator {
 
     public static void checkStringLength(final String value, final int max, final String name) {
         if (value.length() > max) {
-            throw new InvalidLengthException(String.format("%s는 %d보다 작은 값만 입력할 수 있습니다.", name, max));
+            throw new InvalidLengthException(String.format("%s은(는) %d보다 작은 값만 입력할 수 있습니다.", name, max));
         }
     }
 
     public static void checkStringLength(final String value, final int max, final int min, final String name) {
         if (value.length() < min || value.length() > max) {
-            throw new InvalidLengthException(String.format("%s는 %d와 %d 사이 값만 입력할 수 있습니다.", name, min, max));
+            throw new InvalidLengthException(String.format("%s은(는) %d와 %d 사이 값만 입력할 수 있습니다.", name, min, max));
         }
     }
 }

--- a/src/main/java/com/woowacourse/matzip/support/LengthValidator.java
+++ b/src/main/java/com/woowacourse/matzip/support/LengthValidator.java
@@ -8,9 +8,15 @@ public class LengthValidator {
         throw new AssertionError();
     }
 
-    public static void checkStringLength(final String value, final String name, final int max) {
+    public static void checkStringLength(final String value, final int max, final String name) {
         if (value.length() > max) {
             throw new InvalidLengthException(String.format("%s는 %d보다 작은 값만 입력할 수 있습니다.", name, max));
+        }
+    }
+
+    public static void checkStringLength(final String value, final int max, final int min, final String name) {
+        if (value.length() < min || value.length() > max) {
+            throw new InvalidLengthException(String.format("%s는 %d와 %d 사이 값만 입력할 수 있습니다.", name, min, max));
         }
     }
 }

--- a/src/main/java/com/woowacourse/matzip/support/LengthValidator.java
+++ b/src/main/java/com/woowacourse/matzip/support/LengthValidator.java
@@ -1,0 +1,16 @@
+package com.woowacourse.matzip.support;
+
+import com.woowacourse.matzip.exception.InvalidLengthException;
+
+public class LengthValidator {
+
+    private LengthValidator() {
+        throw new AssertionError();
+    }
+
+    public static void checkStringLength(final String value, final String name, final int max) {
+        if (value.length() > max) {
+            throw new InvalidLengthException(String.format("%s는 %d보다 작은 값만 입력할 수 있습니다.", name, max));
+        }
+    }
+}

--- a/src/main/java/com/woowacourse/matzip/support/LengthValidator.java
+++ b/src/main/java/com/woowacourse/matzip/support/LengthValidator.java
@@ -10,13 +10,13 @@ public class LengthValidator {
 
     public static void checkStringLength(final String value, final int max, final String name) {
         if (value.length() > max) {
-            throw new InvalidLengthException(String.format("%s은(는) %d보다 작은 값만 입력할 수 있습니다.", name, max));
+            throw new InvalidLengthException(String.format("%s은(는) 길이가 %d 이하의 값만 입력할 수 있습니다.", name, max));
         }
     }
 
     public static void checkStringLength(final String value, final int max, final int min, final String name) {
         if (value.length() < min || value.length() > max) {
-            throw new InvalidLengthException(String.format("%s은(는) %d와 %d 사이 값만 입력할 수 있습니다.", name, min, max));
+            throw new InvalidLengthException(String.format("%s은(는) 길이가 %d와 %d 사이 값만 입력할 수 있습니다.", name, min, max));
         }
     }
 }

--- a/src/main/java/com/woowacourse/support/exception/ErrorResponse.java
+++ b/src/main/java/com/woowacourse/support/exception/ErrorResponse.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 @Getter
 public class ErrorResponse {
 
+    private static final int VALID_ERROR_FIRST_INDEX = 0;
+
     private String message;
 
     private ErrorResponse() {
@@ -21,7 +23,7 @@ public class ErrorResponse {
 
     public static ErrorResponse from(final MethodArgumentNotValidException exception) {
         return new ErrorResponse(exception.getFieldErrors()
-                .get(0)
+                .get(VALID_ERROR_FIRST_INDEX)
                 .getDefaultMessage());
     }
 

--- a/src/main/java/com/woowacourse/support/exception/ErrorResponse.java
+++ b/src/main/java/com/woowacourse/support/exception/ErrorResponse.java
@@ -1,6 +1,7 @@
 package com.woowacourse.support.exception;
 
 import lombok.Getter;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @Getter
 public class ErrorResponse {
@@ -16,6 +17,12 @@ public class ErrorResponse {
 
     public static ErrorResponse from(final RuntimeException exception) {
         return new ErrorResponse(exception.getMessage());
+    }
+
+    public static ErrorResponse from(final MethodArgumentNotValidException exception) {
+        return new ErrorResponse(exception.getFieldErrors()
+                .get(0)
+                .getDefaultMessage());
     }
 
     public static ErrorResponse from(final String message) {

--- a/src/main/java/com/woowacourse/support/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/woowacourse/support/exception/GlobalControllerAdvice.java
@@ -5,6 +5,7 @@ import com.woowacourse.auth.exception.InvalidTokenException;
 import com.woowacourse.auth.exception.TokenNotFoundException;
 import com.woowacourse.matzip.exception.CampusNotFoundException;
 import com.woowacourse.matzip.exception.InvalidCategoryException;
+import com.woowacourse.matzip.exception.InvalidLengthException;
 import com.woowacourse.matzip.exception.InvalidReviewException;
 import com.woowacourse.matzip.exception.InvalidSortConditionException;
 import com.woowacourse.matzip.exception.MemberNotFoundException;
@@ -45,7 +46,8 @@ public class GlobalControllerAdvice {
     @ExceptionHandler({
             InvalidCategoryException.class,
             InvalidReviewException.class,
-            InvalidSortConditionException.class
+            InvalidSortConditionException.class,
+            InvalidLengthException.class
     })
     public ResponseEntity<ErrorResponse> businessExceptionHandler(final RuntimeException e) {
         return ResponseEntity.badRequest().body(ErrorResponse.from(e));

--- a/src/main/java/com/woowacourse/support/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/woowacourse/support/exception/GlobalControllerAdvice.java
@@ -11,6 +11,7 @@ import com.woowacourse.matzip.exception.MemberNotFoundException;
 import com.woowacourse.matzip.exception.RestaurantNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -47,6 +48,13 @@ public class GlobalControllerAdvice {
             InvalidSortConditionException.class
     })
     public ResponseEntity<ErrorResponse> businessExceptionHandler(final RuntimeException e) {
+        return ResponseEntity.badRequest().body(ErrorResponse.from(e));
+    }
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class
+    })
+    public ResponseEntity<ErrorResponse> springValidationExceptionHandler(final MethodArgumentNotValidException e) {
         return ResponseEntity.badRequest().body(ErrorResponse.from(e));
     }
 

--- a/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
+++ b/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
@@ -35,8 +35,22 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         리뷰_작성에_성공한다(response);
     }
 
-    private void 리뷰_작성에_성공한다(final ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    @Test
+    void 리뷰_작성_시_null_리뷰() {
+        String accessToken = 로그인_토큰();
+        ReviewCreateRequest request = new ReviewCreateRequest(null, 4, "무닭볶음탕 (중)");
+
+        ExtractableResponse<Response> response = 리뷰_생성_요청(식당_ID, accessToken, request);
+        리뷰_작성에_실패한다(response);
+    }
+
+    @Test
+    void 리뷰_작성_시_null_메뉴() {
+        String accessToken = 로그인_토큰();
+        ReviewCreateRequest request = new ReviewCreateRequest("맛있네요.", 4, null);
+
+        ExtractableResponse<Response> response = 리뷰_생성_요청(식당_ID, accessToken, request);
+        리뷰_작성에_실패한다(response);
     }
 
     @Test
@@ -46,6 +60,14 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         }
         ExtractableResponse<Response> response = 리뷰_조회_요청(식당_ID, 2, 5);
         리뷰_조회에_성공한다(response);
+    }
+
+    private void 리뷰_작성에_성공한다(final ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    private void 리뷰_작성에_실패한다(final ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
     private void 리뷰_조회에_성공한다(final ExtractableResponse<Response> response) {

--- a/src/test/java/com/woowacourse/matzip/domain/campus/CampusTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/campus/CampusTest.java
@@ -24,6 +24,6 @@ public class CampusTest {
 
         assertThatThrownBy(() -> Campus.builder().name(name).build())
                 .isInstanceOf(InvalidLengthException.class)
-                .hasMessage("캠퍼스 이름은(는) 20보다 작은 값만 입력할 수 있습니다.");
+                .hasMessage("캠퍼스 이름은(는) 길이가 20 이하의 값만 입력할 수 있습니다.");
     }
 }

--- a/src/test/java/com/woowacourse/matzip/domain/campus/CampusTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/campus/CampusTest.java
@@ -1,17 +1,14 @@
 package com.woowacourse.matzip.domain.campus;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.matzip.exception.InvalidLengthException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class CampusTest {
-
-    @Test
-    void 캠퍼스_생성() {
-        assertThat(new Campus(1L, "JAMSIL")).isInstanceOf(Campus.class);
-    }
 
     @ParameterizedTest
     @CsvSource(value = {"1,true", "2,false"})
@@ -19,5 +16,14 @@ public class CampusTest {
         Campus campus = new Campus(1L, "JAMSIL");
 
         assertThat(campus.isSameId(id)).isEqualTo(expected);
+    }
+
+    @Test
+    void 캠퍼스_생성_시_이름_길이_제한() {
+        String name = "캠퍼스의 이름이 이렇게 길 수 없습니다.";
+
+        assertThatThrownBy(() -> Campus.builder().name(name).build())
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage("캠퍼스 이름은(는) 20보다 작은 값만 입력할 수 있습니다.");
     }
 }

--- a/src/test/java/com/woowacourse/matzip/domain/category/CategoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/category/CategoryTest.java
@@ -3,7 +3,7 @@ package com.woowacourse.matzip.domain.category;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.woowacourse.matzip.exception.InvalidCategoryException;
+import com.woowacourse.matzip.exception.InvalidLengthException;
 import org.junit.jupiter.api.Test;
 
 public class CategoryTest {
@@ -11,8 +11,8 @@ public class CategoryTest {
     @Test
     void 카테고리의_이름_제한길이_초과시_예외발생() {
         assertThatThrownBy(() -> new Category(1L, "abcdefghijk"))
-                .isInstanceOf(InvalidCategoryException.class)
-                .hasMessage("카테고리의 이름은 10자를 넘을 수 없습니다.");
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage("카테고리의 이름은(는) 길이가 10 이하의 값만 입력할 수 있습니다.");
     }
 
     @Test

--- a/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepositoryTest.java
@@ -88,7 +88,7 @@ public class RestaurantRepositoryTest {
         memberRepository.save(member);
         for (int i = 0; i < 3; i++) {
             reviewRepository.save(createTestReview(member, restaurant1.getId(), 5));
-            reviewRepository.save(createTestReview(member, restaurant2.getId(), 0));
+            reviewRepository.save(createTestReview(member, restaurant2.getId(), 1));
         }
 
         Slice<Restaurant> page = restaurantRepository.findPageByCampusIdOrderByRatingDesc(1L, null,

--- a/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantTest.java
@@ -1,0 +1,21 @@
+package com.woowacourse.matzip.domain.restaurant;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.matzip.exception.InvalidLengthException;
+import org.junit.jupiter.api.Test;
+
+public class RestaurantTest {
+
+    @Test
+    void 식당_생성_시_이름_길이_제한() {
+        String name = "식당의 이름이 이렇게 길 수 없습니다.";
+
+        assertThatThrownBy(() -> Restaurant.builder()
+                .name(name)
+                .distance(1L)
+                .build())
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage("식당 이름은(는) 길이가 20 이하의 값만 입력할 수 있습니다.");
+    }
+}

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
@@ -2,7 +2,9 @@ package com.woowacourse.matzip.domain.review;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.matzip.exception.InvalidLengthException;
 import com.woowacourse.matzip.exception.InvalidReviewException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -14,5 +16,17 @@ public class ReviewTest {
         assertThatThrownBy(() -> Review.builder().rating(score).build())
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage("리뷰 점수는 0점부터 5점까지만 가능합니다.");
+    }
+
+    @Test
+    void 리뷰_생성_시_메뉴_이름_길이_제한() {
+        String menu = "리뷰의 메뉴 이름이 이렇게 길 수 없습니다.";
+
+        assertThatThrownBy(() -> Review.builder()
+                .menu(menu)
+                .content("리뷰내용")
+                .build())
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage("메뉴의 이름은(는) 길이가 20 이하의 값만 입력할 수 있습니다.");
     }
 }

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
@@ -13,11 +13,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class ReviewTest {
 
     @ParameterizedTest
-    @ValueSource(ints = {-1, 6})
+    @ValueSource(ints = {0, 6})
     void 별점_범위제한인_경우_예외발생(final int score) {
         assertThatThrownBy(() -> Review.builder().rating(score).build())
                 .isInstanceOf(InvalidReviewException.class)
-                .hasMessage("리뷰 점수는 0점부터 5점까지만 가능합니다.");
+                .hasMessage("리뷰 점수는 1점부터 5점까지만 가능합니다.");
     }
 
     @Test
@@ -27,6 +27,7 @@ public class ReviewTest {
         assertThatThrownBy(() -> Review.builder()
                 .menu(menu)
                 .content("리뷰내용")
+                .rating(3)
                 .build())
                 .isInstanceOf(InvalidLengthException.class)
                 .hasMessage("메뉴의 이름은(는) 길이가 20 이하의 값만 입력할 수 있습니다.");
@@ -41,6 +42,7 @@ public class ReviewTest {
         assertThatThrownBy(() -> Review.builder()
                 .menu("메뉴")
                 .content(content)
+                .rating(3)
                 .build())
                 .isInstanceOf(InvalidLengthException.class)
                 .hasMessage("리뷰 내용은(는) 길이가 255 이하의 값만 입력할 수 있습니다.");

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.matzip.exception.InvalidLengthException;
 import com.woowacourse.matzip.exception.InvalidReviewException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,5 +30,19 @@ public class ReviewTest {
                 .build())
                 .isInstanceOf(InvalidLengthException.class)
                 .hasMessage("메뉴의 이름은(는) 길이가 20 이하의 값만 입력할 수 있습니다.");
+    }
+
+    @Test
+    void 리뷰_생성_시_리뷰_내용_길이_제한() {
+        String content = IntStream.rangeClosed(1, 256)
+                .mapToObj(index -> "a")
+                .collect(Collectors.joining());
+
+        assertThatThrownBy(() -> Review.builder()
+                .menu("메뉴")
+                .content(content)
+                .build())
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage("리뷰 내용은(는) 길이가 255 이하의 값만 입력할 수 있습니다.");
     }
 }

--- a/src/test/java/com/woowacourse/matzip/support/LengthValidatorTest.java
+++ b/src/test/java/com/woowacourse/matzip/support/LengthValidatorTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.matzip.exception.InvalidLengthException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class LengthValidatorTest {
 
@@ -13,8 +15,20 @@ public class LengthValidatorTest {
         String name = "리뷰";
         int max = 5;
 
-        assertThatThrownBy(() -> LengthValidator.checkStringLength(value, name, max))
+        assertThatThrownBy(() -> LengthValidator.checkStringLength(value, max, name))
                 .isInstanceOf(InvalidLengthException.class)
                 .hasMessage(name + "는 " + max + "보다 작은 값만 입력할 수 있습니다.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "리뷰의 길이를 굉장히 길게 작성하겠습니다."})
+    void 값이_범위에_없는_경우_예외발생(final String value) {
+        int max = 5;
+        int min = 1;
+        String name = "리뷰";
+
+        assertThatThrownBy(() -> LengthValidator.checkStringLength(value, max, min, name))
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage(name + "는 " + min + "와 " + max + " 사이 값만 입력할 수 있습니다.");
     }
 }

--- a/src/test/java/com/woowacourse/matzip/support/LengthValidatorTest.java
+++ b/src/test/java/com/woowacourse/matzip/support/LengthValidatorTest.java
@@ -1,0 +1,20 @@
+package com.woowacourse.matzip.support;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.matzip.exception.InvalidLengthException;
+import org.junit.jupiter.api.Test;
+
+public class LengthValidatorTest {
+
+    @Test
+    void 값이_최대길이보다_긴_경우_예외발생() {
+        String value = "리뷰의 길이를 굉장히 길게 작성하겠습니다.";
+        String name = "리뷰";
+        int max = 5;
+
+        assertThatThrownBy(() -> LengthValidator.checkStringLength(value, name, max))
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage(name + "는 " + max + "보다 작은 값만 입력할 수 있습니다.");
+    }
+}

--- a/src/test/java/com/woowacourse/matzip/support/LengthValidatorTest.java
+++ b/src/test/java/com/woowacourse/matzip/support/LengthValidatorTest.java
@@ -17,7 +17,7 @@ public class LengthValidatorTest {
 
         assertThatThrownBy(() -> LengthValidator.checkStringLength(value, max, name))
                 .isInstanceOf(InvalidLengthException.class)
-                .hasMessage(name + "은(는) " + max + "보다 작은 값만 입력할 수 있습니다.");
+                .hasMessage(name + "은(는) 길이가 " + max + " 이하의 값만 입력할 수 있습니다.");
     }
 
     @ParameterizedTest
@@ -29,6 +29,6 @@ public class LengthValidatorTest {
 
         assertThatThrownBy(() -> LengthValidator.checkStringLength(value, max, min, name))
                 .isInstanceOf(InvalidLengthException.class)
-                .hasMessage(name + "은(는) " + min + "와 " + max + " 사이 값만 입력할 수 있습니다.");
+                .hasMessage(name + "은(는) 길이가 " + min + "와 " + max + " 사이 값만 입력할 수 있습니다.");
     }
 }

--- a/src/test/java/com/woowacourse/matzip/support/LengthValidatorTest.java
+++ b/src/test/java/com/woowacourse/matzip/support/LengthValidatorTest.java
@@ -17,7 +17,7 @@ public class LengthValidatorTest {
 
         assertThatThrownBy(() -> LengthValidator.checkStringLength(value, max, name))
                 .isInstanceOf(InvalidLengthException.class)
-                .hasMessage(name + "는 " + max + "보다 작은 값만 입력할 수 있습니다.");
+                .hasMessage(name + "은(는) " + max + "보다 작은 값만 입력할 수 있습니다.");
     }
 
     @ParameterizedTest
@@ -29,6 +29,6 @@ public class LengthValidatorTest {
 
         assertThatThrownBy(() -> LengthValidator.checkStringLength(value, max, min, name))
                 .isInstanceOf(InvalidLengthException.class)
-                .hasMessage(name + "는 " + min + "와 " + max + " 사이 값만 입력할 수 있습니다.");
+                .hasMessage(name + "은(는) " + min + "와 " + max + " 사이 값만 입력할 수 있습니다.");
     }
 }


### PR DESCRIPTION
## issue: #43

## as-is
- input값에 대한 도메인 객체들 길이 제한이 존재하지 않음
- ReviewCreateRequest의 null 제한 누락

## to-be
- 스키마 정보와 동일한 길이 validation 추가
- `matzip.support.LengthValidator.java` util 클래스 추가
    - max, min-max 길이 제한 예외처리가 공통적으로 들어가는 내용이 많아 묶어서 처리하기 위한 용도
    - `InvalidLengthException`을 반환하고 있음.
    - _해당 util 클래스가 필요한가 불필요한가에 대한 논의필요 (오버프로그래밍이라고 생각하고 있기는 함)_
- spring-validation 추가로 앞단에서 처리 추가
    - `MethodArgumentNotValidException`에 대한 예외처리진행중 -> 해당 exception에서 message가 2개 이상이 발생해도 현재는 list가 아닌 String으로 반환하고 있기 때문에 가장 먼저 나온 에러를 `get(0)`하여 하나의 메시지만 반환하도록 처리중