### PR TITLE
feat: 리뷰 생성 시 생성 일자 추가

### DIFF
--- a/src/main/java/com/woowacourse/MatzipApplication.java
+++ b/src/main/java/com/woowacourse/MatzipApplication.java
@@ -1,5 +1,7 @@
 package com.woowacourse;
 
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -8,6 +10,11 @@ public class MatzipApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(MatzipApplication.class, args);
+    }
+
+    @PostConstruct
+    void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 
 }

--- a/src/main/java/com/woowacourse/matzip/domain/review/Review.java
+++ b/src/main/java/com/woowacourse/matzip/domain/review/Review.java
@@ -3,9 +3,11 @@ package com.woowacourse.matzip.domain.review;
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.exception.InvalidReviewException;
 import com.woowacourse.matzip.support.LengthValidator;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -15,9 +17,12 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "review")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 public class Review {
 
@@ -46,12 +51,16 @@ public class Review {
     @Column(name = "menu", length = MAX_MENU_LENGTH, nullable = false)
     private String menu;
 
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
     protected Review() {
     }
 
     @Builder
     public Review(final Long id, final Member member, final Long restaurantId, final String content, final int rating,
-                  final String menu) {
+                  final String menu, final LocalDateTime createdAt) {
         validateRating(rating);
         LengthValidator.checkStringLength(menu, MAX_MENU_LENGTH, "메뉴의 이름");
         LengthValidator.checkStringLength(content, MAX_CONTENT_LENGTH, "리뷰 내용");
@@ -61,6 +70,7 @@ public class Review {
         this.content = content;
         this.rating = rating;
         this.menu = menu;
+        this.createdAt = createdAt;
     }
 
     private void validateRating(final int rating) {

--- a/src/main/java/com/woowacourse/support/config/JpaConfig.java
+++ b/src/main/java/com/woowacourse/support/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.woowacourse.support.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/review/ReviewRepositoryTest.java
@@ -5,13 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.member.MemberRepository;
+import com.woowacourse.support.config.JpaConfig;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 class ReviewRepositoryTest {
 
     @Autowired
@@ -79,5 +83,25 @@ class ReviewRepositoryTest {
                 .orElse(0.0);
 
         assertThat(average).isEqualTo(4.5);
+    }
+
+    @Test
+    void 리뷰_저장_시_생성시간이_추가된다() {
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        Member member = Member.builder()
+                .githubId("githubId")
+                .username("username")
+                .profileImage("url")
+                .build();
+        Review review = reviewRepository.save(Review.builder()
+                .member(memberRepository.save(member))
+                .restaurantId(1L)
+                .content("맛있어요")
+                .rating(5)
+                .menu("족발")
+                .build());
+
+        assertThat(review.getCreatedAt()).isAfter(currentTime);
     }
 }

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -34,6 +34,7 @@ CREATE TABLE review
     content       varchar(255) NULL,
     rating        int          NOT NULL,
     menu          varchar(20)  NOT NULL,
+    created_at    TIMESTAMP    NOT NULL,
     PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
## issue: #47 

## as-is
- 리뷰 생성일자 누락

## to-be
- application 실행 시 timezone asia/seoul 변경
- `@EnableJpaAuditing` 용 configuration 추가
- 리뷰 내 created_at 필드 추가
- created_at 정상 저장되는지 확인 테스트 추가
