### PR TITLE
feat: 유저 저장 시 생성시간 필드를 추가한다

### DIFF
--- a/src/main/java/com/woowacourse/matzip/domain/member/Member.java
+++ b/src/main/java/com/woowacourse/matzip/domain/member/Member.java
@@ -1,17 +1,22 @@
 package com.woowacourse.matzip.domain.member;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "member")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 public class Member {
 
@@ -27,6 +32,10 @@ public class Member {
 
     @Column(name = "profile_image", nullable = false)
     private String profileImage;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
 
     protected Member() {
     }

--- a/src/test/java/com/woowacourse/matzip/domain/member/MemberRepositoryTest.java
+++ b/src/test/java/com/woowacourse/matzip/domain/member/MemberRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.woowacourse.matzip.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.support.config.JpaConfig;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 유저_저장_시_생성시간이_추가된다() {
+        LocalDateTime currentTime = LocalDateTime.now();
+        Member member = memberRepository.save(Member.builder()
+                .githubId("githubId")
+                .username("username")
+                .profileImage("url")
+                .build());
+
+        assertThat(member.getCreatedAt()).isAfter(currentTime);
+    }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE member
     github_id     varchar(255) NOT NULL UNIQUE,
     username      varchar(255) NOT NULL,
     profile_image varchar(255) NOT NULL,
+    created_at    TIMESTAMP    NOT NULL,
     PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
## issue: #55 

## as-is
- 유저 내 생성일자 필드 누락

## to-be
- 유저 생성일자 저장을 위해 create_at 추가
