### PR TITLE
chore: createDocument 작업 뒤에 JAR 만드는 디렉토리로 옮기는 copyDocument 태스크 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'org.asciidoctor.convert' version '1.5.9.2'
     id 'java'
     id 'jacoco'
-    id "org.sonarqube" version "3.4.0.2513"
 }
 
 apply from: 'test.gradle'
@@ -56,12 +55,12 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
 }
 
-tasks.named('test') {
+test {
     outputs.dir snippetsDir
     useJUnitPlatform()
 }
 
-tasks.named('asciidoctor') {
+asciidoctor {
     inputs.dir snippetsDir
     dependsOn test
 }
@@ -73,15 +72,13 @@ task createDocument(type: Copy) {
     into file("src/main/resources/static")
 }
 
-bootJar {
+task copyDocument(type: Copy) {
     dependsOn createDocument
+
+    from file("src/main/resources/static")
+    into file("build/resources/main/static")
 }
 
-// for sonar cloud
-sonarqube {
-    properties {
-        property "sonar.projectKey", "The-Fellowship-of-the-matzip_mat.zip-back"
-        property "sonar.organization", "the-fellowship-of-the-matzip"
-        property "sonar.host.url", "https://sonarcloud.io"
-    }
+bootJar {
+    dependsOn copyDocument
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.asciidoctor.convert' version '1.5.9.2'
     id 'java'
     id 'jacoco'
+    id "org.sonarqube" version "3.4.0.2513"
 }
 
 apply from: 'test.gradle'
@@ -82,6 +83,7 @@ task copyDocument(type: Copy) {
 bootJar {
     dependsOn copyDocument
 }
+
 sonarqube {
     properties {
         property "sonar.projectKey", "The-Fellowship-of-the-matzip_mat.zip-back"

--- a/build.gradle
+++ b/build.gradle
@@ -82,3 +82,10 @@ task copyDocument(type: Copy) {
 bootJar {
     dependsOn copyDocument
 }
+sonarqube {
+    properties {
+        property "sonar.projectKey", "The-Fellowship-of-the-matzip_mat.zip-back"
+        property "sonar.organization", "the-fellowship-of-the-matzip"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
+}


### PR DESCRIPTION
## issue: closes #58 

## as-is
- REST Docs 결과물인 `index.html`이 프로덕션 코드의 static에는 생기지만, 실제 JAR를 만들 때는 포함되지 않음.

## to-be
- `createDocument` 작업 뒤 JAR 파일을 만드는 디렉토리에 복사하는 `copyDocument` 작업 추가
