### PR TITLE
refactor: 인터셉터 프록시패턴 적용

### DIFF
--- a/src/main/java/com/woowacourse/auth/config/AuthConfig.java
+++ b/src/main/java/com/woowacourse/auth/config/AuthConfig.java
@@ -1,10 +1,13 @@
 package com.woowacourse.auth.config;
 
 import com.woowacourse.auth.presentation.AuthenticationArgumentResolver;
-import com.woowacourse.auth.presentation.LoginInterceptor;
+import com.woowacourse.auth.presentation.interceptor.LoginInterceptor;
+import com.woowacourse.auth.presentation.interceptor.PathMatcherInterceptor;
+import com.woowacourse.auth.presentation.interceptor.PathMethod;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -22,8 +25,13 @@ public class AuthConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(loginInterceptor)
-                .addPathPatterns("/api/restaurants/*/reviews");
+        registry.addInterceptor(loginInterceptor());
+    }
+
+    private HandlerInterceptor loginInterceptor() {
+        return new PathMatcherInterceptor(loginInterceptor)
+                .excludePathPattern("/**", PathMethod.OPTIONS)
+                .includePathPattern("/api/restaurants/*/reviews", PathMethod.POST);
     }
 
     @Override

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/LoginInterceptor.java
@@ -1,13 +1,12 @@
-package com.woowacourse.auth.presentation;
+package com.woowacourse.auth.presentation.interceptor;
 
 import com.woowacourse.auth.application.JwtTokenProvider;
 import com.woowacourse.auth.exception.TokenNotFoundException;
+import com.woowacourse.auth.presentation.AuthenticationContext;
 import com.woowacourse.auth.support.AuthorizationExtractor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
-import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
@@ -23,16 +22,9 @@ public class LoginInterceptor implements HandlerInterceptor {
     }
 
     @Override
-    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+    public boolean preHandle(final HttpServletRequest request,
+                             final HttpServletResponse response,
                              final Object handler) {
-        if (CorsUtils.isPreFlightRequest(request)) {
-            return true;
-        }
-
-        if (HttpMethod.GET.matches(request.getMethod())) {
-            return true;
-        }
-
         final String token = AuthorizationExtractor.extract(request)
                 .orElseThrow(TokenNotFoundException::new);
         authenticationContext.setPrincipal(jwtTokenProvider.getPayload(token));

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/PathContainer.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/PathContainer.java
@@ -1,0 +1,42 @@
+package com.woowacourse.auth.presentation.interceptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+public class PathContainer {
+
+    private final PathMatcher pathMatcher;
+    private final List<RequestPathPattern> includePathPatterns;
+    private final List<RequestPathPattern> excludePathPatterns;
+
+    public PathContainer() {
+        this.pathMatcher = new AntPathMatcher();
+        this.includePathPatterns = new ArrayList<>();
+        this.excludePathPatterns = new ArrayList<>();
+    }
+
+    public boolean notIncludedPath(final String targetPath, final String pathMethod) {
+        boolean excludePattern = excludePathPatterns.stream()
+                .anyMatch(requestPath -> anyMatchPathPattern(targetPath, pathMethod, requestPath));
+
+        boolean includePattern = includePathPatterns.stream()
+                .anyMatch(requestPath -> anyMatchPathPattern(targetPath, pathMethod, requestPath));
+
+        return excludePattern || !includePattern;
+    }
+
+    private boolean anyMatchPathPattern(final String targetPath, final String pathMethod, final RequestPathPattern requestPath) {
+        return pathMatcher.match(requestPath.getPath(), targetPath) &&
+                requestPath.matchesMethod(pathMethod);
+    }
+
+    public void includePathPattern(final String targetPath, final PathMethod pathMethod) {
+        this.includePathPatterns.add(new RequestPathPattern(targetPath, pathMethod));
+    }
+
+    public void excludePathPattern(String targetPath, PathMethod pathMethod) {
+        this.excludePathPatterns.add(new RequestPathPattern(targetPath, pathMethod));
+    }
+}

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/PathContainer.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/PathContainer.java
@@ -19,26 +19,19 @@ public class PathContainer {
 
     public boolean isNotIncludedPath(final String targetPath, final String pathMethod) {
         boolean isExcludePattern = excludePathPatterns.stream()
-                .anyMatch(pathPattern -> anyMatchPathPattern(targetPath, pathMethod, pathPattern));
+                .anyMatch(pathPattern -> pathPattern.matches(pathMatcher, targetPath, pathMethod));
 
         boolean isNotIncludePattern = includePathPatterns.stream()
-                .noneMatch(pathPattern -> anyMatchPathPattern(targetPath, pathMethod, pathPattern));
+                .noneMatch(pathPattern -> pathPattern.matches(pathMatcher, targetPath, pathMethod));
 
         return isExcludePattern || isNotIncludePattern;
-    }
-
-    private boolean anyMatchPathPattern(final String targetPath,
-                                        final String pathMethod,
-                                        final RequestPathPattern requestPathPattern) {
-        return pathMatcher.match(requestPathPattern.getPath(), targetPath) &&
-                requestPathPattern.matchesMethod(pathMethod);
     }
 
     public void includePathPattern(final String targetPath, final PathMethod pathMethod) {
         this.includePathPatterns.add(new RequestPathPattern(targetPath, pathMethod));
     }
 
-    public void excludePathPattern(String targetPath, PathMethod pathMethod) {
+    public void excludePathPattern(final String targetPath, final PathMethod pathMethod) {
         this.excludePathPatterns.add(new RequestPathPattern(targetPath, pathMethod));
     }
 }

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/PathContainer.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/PathContainer.java
@@ -17,19 +17,21 @@ public class PathContainer {
         this.excludePathPatterns = new ArrayList<>();
     }
 
-    public boolean notIncludedPath(final String targetPath, final String pathMethod) {
-        boolean excludePattern = excludePathPatterns.stream()
-                .anyMatch(requestPath -> anyMatchPathPattern(targetPath, pathMethod, requestPath));
+    public boolean isNotIncludedPath(final String targetPath, final String pathMethod) {
+        boolean isExcludePattern = excludePathPatterns.stream()
+                .anyMatch(pathPattern -> anyMatchPathPattern(targetPath, pathMethod, pathPattern));
 
-        boolean includePattern = includePathPatterns.stream()
-                .anyMatch(requestPath -> anyMatchPathPattern(targetPath, pathMethod, requestPath));
+        boolean isNotIncludePattern = includePathPatterns.stream()
+                .noneMatch(pathPattern -> anyMatchPathPattern(targetPath, pathMethod, pathPattern));
 
-        return excludePattern || !includePattern;
+        return isExcludePattern || isNotIncludePattern;
     }
 
-    private boolean anyMatchPathPattern(final String targetPath, final String pathMethod, final RequestPathPattern requestPath) {
-        return pathMatcher.match(requestPath.getPath(), targetPath) &&
-                requestPath.matchesMethod(pathMethod);
+    private boolean anyMatchPathPattern(final String targetPath,
+                                        final String pathMethod,
+                                        final RequestPathPattern requestPathPattern) {
+        return pathMatcher.match(requestPathPattern.getPath(), targetPath) &&
+                requestPathPattern.matchesMethod(pathMethod);
     }
 
     public void includePathPattern(final String targetPath, final PathMethod pathMethod) {

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/PathMatcherInterceptor.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/PathMatcherInterceptor.java
@@ -1,0 +1,36 @@
+package com.woowacourse.auth.presentation.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class PathMatcherInterceptor implements HandlerInterceptor {
+
+    private final HandlerInterceptor handlerInterceptor;
+    private final PathContainer pathContainer;
+
+    public PathMatcherInterceptor(final HandlerInterceptor handlerInterceptor) {
+        this.handlerInterceptor = handlerInterceptor;
+        this.pathContainer = new PathContainer();
+    }
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request,
+                             final HttpServletResponse response,
+                             final Object handler) throws Exception {
+        if (pathContainer.notIncludedPath(request.getServletPath(), request.getMethod())) {
+            return true;
+        }
+        return handlerInterceptor.preHandle(request, response, handler);
+    }
+
+    public PathMatcherInterceptor includePathPattern(final String pathPattern, final PathMethod pathMethod) {
+        pathContainer.includePathPattern(pathPattern, pathMethod);
+        return this;
+    }
+
+    public PathMatcherInterceptor excludePathPattern(final String pathPattern, final PathMethod pathMethod) {
+        pathContainer.excludePathPattern(pathPattern, pathMethod);
+        return this;
+    }
+}

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/PathMatcherInterceptor.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/PathMatcherInterceptor.java
@@ -18,7 +18,7 @@ public class PathMatcherInterceptor implements HandlerInterceptor {
     public boolean preHandle(final HttpServletRequest request,
                              final HttpServletResponse response,
                              final Object handler) throws Exception {
-        if (pathContainer.notIncludedPath(request.getServletPath(), request.getMethod())) {
+        if (pathContainer.isNotIncludedPath(request.getServletPath(), request.getMethod())) {
             return true;
         }
         return handlerInterceptor.preHandle(request, response, handler);

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/PathMethod.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/PathMethod.java
@@ -15,7 +15,7 @@ public enum PathMethod {
         @Override
         public boolean matches(final String method) {
             return Arrays.stream(values())
-                    .filter(value -> !value.equals(ANY))
+                    .filter(value -> value != ANY)
                     .anyMatch(value -> value.name().equalsIgnoreCase(method));
         }
     };

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/PathMethod.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/PathMethod.java
@@ -1,0 +1,26 @@
+package com.woowacourse.auth.presentation.interceptor;
+
+import java.util.Arrays;
+
+public enum PathMethod {
+    GET,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    OPTIONS,
+    TRACE,
+    HEAD,
+    ANY {
+        @Override
+        public boolean matches(final String method) {
+            return Arrays.stream(values())
+                    .filter(value -> !value.equals(ANY))
+                    .anyMatch(value -> value.name().equalsIgnoreCase(method));
+        }
+    };
+
+    public boolean matches(final String method) {
+        return name().equalsIgnoreCase(method);
+    }
+}

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/RequestPathPattern.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/RequestPathPattern.java
@@ -2,6 +2,7 @@ package com.woowacourse.auth.presentation.interceptor;
 
 import java.util.Objects;
 import lombok.Getter;
+import org.springframework.util.PathMatcher;
 
 @Getter
 public class RequestPathPattern {
@@ -14,7 +15,11 @@ public class RequestPathPattern {
         this.method = Objects.requireNonNull(method);
     }
 
-    public boolean matchesMethod(final String pathMethod) {
+    public boolean matches(final PathMatcher pathMatcher, final String targetPath, final String pathMethod) {
+        return pathMatcher.match(path, targetPath) && matchesMethod(pathMethod);
+    }
+
+    private boolean matchesMethod(final String pathMethod) {
         return method.matches(pathMethod);
     }
 }

--- a/src/main/java/com/woowacourse/auth/presentation/interceptor/RequestPathPattern.java
+++ b/src/main/java/com/woowacourse/auth/presentation/interceptor/RequestPathPattern.java
@@ -1,0 +1,20 @@
+package com.woowacourse.auth.presentation.interceptor;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class RequestPathPattern {
+
+    private final String path;
+    private final PathMethod method;
+
+    public RequestPathPattern(final String path, final PathMethod method) {
+        this.path = Objects.requireNonNull(path);
+        this.method = Objects.requireNonNull(method);
+    }
+
+    public boolean matchesMethod(final String pathMethod) {
+        return method.matches(pathMethod);
+    }
+}

--- a/src/test/java/com/woowacourse/auth/presentation/interceptor/PathContainerTest.java
+++ b/src/test/java/com/woowacourse/auth/presentation/interceptor/PathContainerTest.java
@@ -3,6 +3,8 @@ package com.woowacourse.auth.presentation.interceptor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class PathContainerTest {
 
@@ -11,6 +13,14 @@ class PathContainerTest {
         PathContainer pathContainer = new PathContainer();
         pathContainer.includePathPattern("/api/reviews", PathMethod.DELETE);
         assertThat(pathContainer.isNotIncludedPath("/api/reviews", "PUT")).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS"})
+    void include에_포함된_경로(String method) {
+        PathContainer pathContainer = new PathContainer();
+        pathContainer.includePathPattern("/api/reviews", PathMethod.ANY);
+        assertThat(pathContainer.isNotIncludedPath("/api/reviews", method)).isFalse();
     }
 
     @Test

--- a/src/test/java/com/woowacourse/auth/presentation/interceptor/PathContainerTest.java
+++ b/src/test/java/com/woowacourse/auth/presentation/interceptor/PathContainerTest.java
@@ -10,7 +10,7 @@ class PathContainerTest {
     void include에_포함_되지_않은_경로() {
         PathContainer pathContainer = new PathContainer();
         pathContainer.includePathPattern("/api/reviews", PathMethod.DELETE);
-        assertThat(pathContainer.notIncludedPath("/api/reviews", "PUT")).isTrue();
+        assertThat(pathContainer.isNotIncludedPath("/api/reviews", "PUT")).isTrue();
     }
 
     @Test
@@ -18,6 +18,6 @@ class PathContainerTest {
         PathContainer pathContainer = new PathContainer();
         pathContainer.includePathPattern("/api/reviews", PathMethod.ANY);
         pathContainer.excludePathPattern("/api/reviews", PathMethod.GET);
-        assertThat(pathContainer.notIncludedPath("/api/reviews", "GET")).isTrue();
+        assertThat(pathContainer.isNotIncludedPath("/api/reviews", "GET")).isTrue();
     }
 }

--- a/src/test/java/com/woowacourse/auth/presentation/interceptor/PathContainerTest.java
+++ b/src/test/java/com/woowacourse/auth/presentation/interceptor/PathContainerTest.java
@@ -1,0 +1,23 @@
+package com.woowacourse.auth.presentation.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PathContainerTest {
+
+    @Test
+    void include에_포함_되지_않은_경로() {
+        PathContainer pathContainer = new PathContainer();
+        pathContainer.includePathPattern("/api/reviews", PathMethod.DELETE);
+        assertThat(pathContainer.notIncludedPath("/api/reviews", "PUT")).isTrue();
+    }
+
+    @Test
+    void exclude에_포함된_경로() {
+        PathContainer pathContainer = new PathContainer();
+        pathContainer.includePathPattern("/api/reviews", PathMethod.ANY);
+        pathContainer.excludePathPattern("/api/reviews", PathMethod.GET);
+        assertThat(pathContainer.notIncludedPath("/api/reviews", "GET")).isTrue();
+    }
+}

--- a/src/test/java/com/woowacourse/auth/presentation/interceptor/PathMethodTest.java
+++ b/src/test/java/com/woowacourse/auth/presentation/interceptor/PathMethodTest.java
@@ -1,0 +1,37 @@
+package com.woowacourse.auth.presentation.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PathMethodTest {
+
+    @ParameterizedTest
+    @CsvSource(value = {"GET:GET", "POST:POST", "PUT:PUT", "PATCH:PATCH", "DELETE:DELETE", "OPTIONS:OPTIONS",
+            "TRACE:TRACE", "HEAD:HEAD"}, delimiter = ':')
+    void 대문자가_일치한다(String method, PathMethod pathMethod) {
+        assertThat(pathMethod.matches(method)).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"get:GET", "post:POST", "put:PUT", "patch:PATCH", "delete:DELETE", "options:OPTIONS",
+            "trace:TRACE", "head:HEAD"}, delimiter = ':')
+    void 소문자가_일치한다(String method, PathMethod pathMethod) {
+        assertThat(pathMethod.matches(method)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"get", "GET", "post", "POST", "patch", "PATCH", "delete", "DELETE", "options", "OPTIONS",
+            "trace", "TRACE", "head", "HEAD"})
+    void ANY_와_일치한다(String method) {
+        assertThat(PathMethod.ANY.matches(method)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"any", "ANY", "GOT", "PAST"})
+    void ANY_와_일치하지_않는다(String method) {
+        assertThat(PathMethod.ANY.matches(method)).isFalse();
+    }
+}

--- a/src/test/java/com/woowacourse/auth/presentation/interceptor/RequestPathPatternTest.java
+++ b/src/test/java/com/woowacourse/auth/presentation/interceptor/RequestPathPatternTest.java
@@ -1,0 +1,14 @@
+package com.woowacourse.auth.presentation.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RequestPathPatternTest {
+
+    @Test
+    void null_일경우_생성할_수_없다() {
+        assertThatThrownBy(() -> new RequestPathPattern(null, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/com/woowacourse/auth/presentation/interceptor/RequestPathPatternTest.java
+++ b/src/test/java/com/woowacourse/auth/presentation/interceptor/RequestPathPatternTest.java
@@ -1,8 +1,10 @@
 package com.woowacourse.auth.presentation.interceptor;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.util.AntPathMatcher;
 
 class RequestPathPatternTest {
 
@@ -10,5 +12,11 @@ class RequestPathPatternTest {
     void null_일경우_생성할_수_없다() {
         assertThatThrownBy(() -> new RequestPathPattern(null, null))
                 .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void request가_ant_match_하다() {
+        RequestPathPattern requestPathPattern = new RequestPathPattern("/api/**", PathMethod.POST);
+        assertThat(requestPathPattern.matches(new AntPathMatcher(), "/api/reviews", "POST")).isTrue();
     }
 }


### PR DESCRIPTION
## issue: #61 

## as-is
- 이슈에 과거 상황을 적어두었습니다.

## to-be

```java
    @Override
    public void addInterceptors(final InterceptorRegistry registry) {
        registry.addInterceptor(loginInterceptor());
    }

  
    private HandlerInterceptor loginInterceptor() {
        return new PathMatcherInterceptor(loginInterceptor)
                .excludePathPattern("/**", PathMethod.OPTIONS) // 검사하고 싶지 않은 path, pattern을 exclude합니다.
                .includePathPattern("/api/restaurants/*/reviews", PathMethod.POST); // 검사하고 싶은 경우엔 include 합니다.
    }
```

## 리뷰해주세요~

1. enum 메서드 상속

PathMethod.ANY에 대한 더 좋은 의견이 있다면 말해주세요.

```java
public enum PathMethod {
    GET,
    POST,
    PUT,
    PATCH,
    DELETE,
    OPTIONS,
    TRACE,
    HEAD,
    ANY {
        @Override
        public boolean matches(final String method) {
            return Arrays.stream(values())
                    .filter(value -> !value.equals(ANY))
                    .anyMatch(value -> value.name().equalsIgnoreCase(method));
        }
    };

    public boolean matches(final String method) {
        return name().equalsIgnoreCase(method);
    }
}
```