### PR TITLE
vaadin을 통한 admin 페이지 구현을 진행한다.

### DIFF
--- a/app-internal-api/build.gradle
+++ b/app-internal-api/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'com.vaadin' version '23.1.7'
+}
+
+ext {
+    set('vaadinVersion', "23.1.7")
+}
+
+dependencies {
+    implementation 'com.vaadin:vaadin-spring-boot-starter'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "com.vaadin:vaadin-bom:${vaadinVersion}"
+    }
+}

--- a/app-internal-api/build.gradle
+++ b/app-internal-api/build.gradle
@@ -8,6 +8,7 @@ ext {
 
 dependencies {
     implementation project(':core')
+    implementation project(':common')
 
     runtimeOnly 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/app-internal-api/build.gradle
+++ b/app-internal-api/build.gradle
@@ -7,7 +7,9 @@ ext {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.vaadin:vaadin-spring-boot-starter'
+    runtimeOnly 'org.springframework.boot:spring-boot-devtools'
 }
 
 dependencyManagement {

--- a/app-internal-api/build.gradle
+++ b/app-internal-api/build.gradle
@@ -7,8 +7,12 @@ ext {
 }
 
 dependencies {
+    implementation project(':core')
+
+    runtimeOnly 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.vaadin:vaadin-spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.springframework.boot:spring-boot-devtools'
 }
 

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/MatzipApplication.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/MatzipApplication.java
@@ -1,0 +1,13 @@
+package com.woowacourse.matzip;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MatzipApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MatzipApplication.class, args);
+    }
+
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminMemberService.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminMemberService.java
@@ -1,0 +1,22 @@
+package com.woowacourse.matzip.application;
+
+import com.woowacourse.matzip.domain.member.Member;
+import com.woowacourse.matzip.repository.MemberRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AdminMemberService {
+
+    private final MemberRepository memberRepository;
+
+    public AdminMemberService(final MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public List<Member> findAll() {
+        return memberRepository.findAll();
+    }
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminRestaurantService.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminRestaurantService.java
@@ -1,0 +1,22 @@
+package com.woowacourse.matzip.application;
+
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import com.woowacourse.matzip.repository.RestaurantRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AdminRestaurantService {
+
+    private final RestaurantRepository restaurantRepository;
+
+    public AdminRestaurantService(final RestaurantRepository restaurantRepository) {
+        this.restaurantRepository = restaurantRepository;
+    }
+
+    public List<Restaurant> findAll() {
+        return restaurantRepository.findAll();
+    }
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminRestaurantService.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminRestaurantService.java
@@ -4,6 +4,8 @@ import com.woowacourse.matzip.application.response.RestaurantResponse;
 import com.woowacourse.matzip.domain.campus.Campus;
 import com.woowacourse.matzip.domain.category.Category;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import com.woowacourse.matzip.exception.CampusNotFoundException;
+import com.woowacourse.matzip.exception.CategoryNotFoundException;
 import com.woowacourse.matzip.repository.CampusRepository;
 import com.woowacourse.matzip.repository.CategoryRepository;
 import com.woowacourse.matzip.repository.RestaurantRepository;
@@ -31,15 +33,15 @@ public class AdminRestaurantService {
     public List<RestaurantResponse> findAll() {
         List<Restaurant> restaurants = restaurantRepository.findAll();
         return restaurants.stream()
-                .map(this::getOf)
+                .map(this::toRestaurantResponse)
                 .collect(Collectors.toList());
     }
 
-    private RestaurantResponse getOf(final Restaurant restaurant) {
+    private RestaurantResponse toRestaurantResponse(final Restaurant restaurant) {
         Category category = categoryReposiroty.findById(restaurant.getId())
-                .orElse(null);
+                .orElseThrow(CategoryNotFoundException::new);
         Campus campus = campusRepository.findById(restaurant.getCampusId())
-                .orElse(null);
+                .orElseThrow(CampusNotFoundException::new);
         return RestaurantResponse.of(restaurant, category, campus);
     }
 }

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminRestaurantService.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminRestaurantService.java
@@ -1,8 +1,14 @@
 package com.woowacourse.matzip.application;
 
+import com.woowacourse.matzip.application.response.RestaurantResponse;
+import com.woowacourse.matzip.domain.campus.Campus;
+import com.woowacourse.matzip.domain.category.Category;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import com.woowacourse.matzip.repository.CampusRepository;
+import com.woowacourse.matzip.repository.CategoryRepository;
 import com.woowacourse.matzip.repository.RestaurantRepository;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,12 +17,29 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminRestaurantService {
 
     private final RestaurantRepository restaurantRepository;
+    private final CategoryRepository categoryReposiroty;
+    private final CampusRepository campusRepository;
 
-    public AdminRestaurantService(final RestaurantRepository restaurantRepository) {
+    public AdminRestaurantService(final RestaurantRepository restaurantRepository,
+                                  final CategoryRepository categoryReposiroty,
+                                  final CampusRepository campusRepository) {
         this.restaurantRepository = restaurantRepository;
+        this.categoryReposiroty = categoryReposiroty;
+        this.campusRepository = campusRepository;
     }
 
-    public List<Restaurant> findAll() {
-        return restaurantRepository.findAll();
+    public List<RestaurantResponse> findAll() {
+        List<Restaurant> restaurants = restaurantRepository.findAll();
+        return restaurants.stream()
+                .map(this::getOf)
+                .collect(Collectors.toList());
+    }
+
+    private RestaurantResponse getOf(final Restaurant restaurant) {
+        Category category = categoryReposiroty.findById(restaurant.getId())
+                .orElse(null);
+        Campus campus = campusRepository.findById(restaurant.getCampusId())
+                .orElse(null);
+        return RestaurantResponse.of(restaurant, category, campus);
     }
 }

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminReviewService.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminReviewService.java
@@ -3,6 +3,7 @@ package com.woowacourse.matzip.application;
 import com.woowacourse.matzip.application.response.ReviewResponse;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
 import com.woowacourse.matzip.domain.review.Review;
+import com.woowacourse.matzip.exception.RestaurantNotFoundException;
 import com.woowacourse.matzip.repository.RestaurantRepository;
 import com.woowacourse.matzip.repository.ReviewRepository;
 import java.util.List;
@@ -26,13 +27,13 @@ public class AdminReviewService {
     public List<ReviewResponse> findAll() {
         return reviewRepository.findAll()
                 .stream()
-                .map(this::getOf)
+                .map(this::toReviewResponse)
                 .collect(Collectors.toList());
     }
 
-    private ReviewResponse getOf(final Review review) {
+    private ReviewResponse toReviewResponse(final Review review) {
         Restaurant restaurant = restaurantRepository.findById(review.getRestaurantId())
-                .orElse(null);
+                .orElseThrow(RestaurantNotFoundException::new);
         return ReviewResponse.of(review, restaurant);
     }
 }

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminReviewService.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/application/AdminReviewService.java
@@ -1,0 +1,38 @@
+package com.woowacourse.matzip.application;
+
+import com.woowacourse.matzip.application.response.ReviewResponse;
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import com.woowacourse.matzip.domain.review.Review;
+import com.woowacourse.matzip.repository.RestaurantRepository;
+import com.woowacourse.matzip.repository.ReviewRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AdminReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final RestaurantRepository restaurantRepository;
+
+    public AdminReviewService(final ReviewRepository reviewRepository,
+                              final RestaurantRepository restaurantRepository) {
+        this.reviewRepository = reviewRepository;
+        this.restaurantRepository = restaurantRepository;
+    }
+
+    public List<ReviewResponse> findAll() {
+        return reviewRepository.findAll()
+                .stream()
+                .map(this::getOf)
+                .collect(Collectors.toList());
+    }
+
+    private ReviewResponse getOf(final Review review) {
+        Restaurant restaurant = restaurantRepository.findById(review.getRestaurantId())
+                .orElse(null);
+        return ReviewResponse.of(review, restaurant);
+    }
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantResponse.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantResponse.java
@@ -1,0 +1,45 @@
+package com.woowacourse.matzip.application.response;
+
+import com.woowacourse.matzip.domain.campus.Campus;
+import com.woowacourse.matzip.domain.category.Category;
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import lombok.Getter;
+
+@Getter
+public class RestaurantResponse {
+
+    private final Long id;
+    private final String categoryName;
+    private final String campusName;
+    private final String name;
+    private final String address;
+    private final Long distance;
+    private final String kakaoMapUrl;
+    private final String imageUrl;
+
+    public RestaurantResponse(final Long id, final String categoryName, final String campusName, final String name,
+                              final String address, final Long distance, final String kakaoMapUrl,
+                              final String imageUrl) {
+        this.id = id;
+        this.categoryName = categoryName;
+        this.campusName = campusName;
+        this.name = name;
+        this.address = address;
+        this.distance = distance;
+        this.kakaoMapUrl = kakaoMapUrl;
+        this.imageUrl = imageUrl;
+    }
+
+    public static RestaurantResponse of(final Restaurant restaurant, final Category category, final Campus campus) {
+        return new RestaurantResponse(
+                restaurant.getId(),
+                category.getName(),
+                campus.getName(),
+                restaurant.getName(),
+                restaurant.getAddress(),
+                restaurant.getDistance(),
+                restaurant.getKakaoMapUrl(),
+                restaurant.getImageUrl()
+        );
+    }
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantResponse.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantResponse.java
@@ -17,7 +17,7 @@ public class RestaurantResponse {
     private final String kakaoMapUrl;
     private final String imageUrl;
 
-    public RestaurantResponse(final Long id, final String categoryName, final String campusName, final String name,
+    private RestaurantResponse(final Long id, final String categoryName, final String campusName, final String name,
                               final String address, final Long distance, final String kakaoMapUrl,
                               final String imageUrl) {
         this.id = id;

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/application/response/ReviewResponse.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/application/response/ReviewResponse.java
@@ -1,0 +1,41 @@
+package com.woowacourse.matzip.application.response;
+
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import com.woowacourse.matzip.domain.review.Review;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ReviewResponse {
+
+    private final Long id;
+    private final String writerName;
+    private final String restaurantName;
+    private final String content;
+    private final int rating;
+    private final String menu;
+    private final LocalDateTime createdAt;
+
+    private ReviewResponse(final Long id, final String writerName, final String restaurantName, final String content,
+                          final int rating, final String menu, final LocalDateTime createdAt) {
+        this.id = id;
+        this.writerName = writerName;
+        this.restaurantName = restaurantName;
+        this.content = content;
+        this.rating = rating;
+        this.menu = menu;
+        this.createdAt = createdAt;
+    }
+
+    public static ReviewResponse of(final Review review, final Restaurant restaurant) {
+        return new ReviewResponse(
+                review.getId(),
+                review.getMember().getUsername(),
+                restaurant.getName(),
+                review.getContent(),
+                review.getRating(),
+                review.getMenu(),
+                review.getCreatedAt()
+        );
+    }
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/repository/CampusRepository.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/repository/CampusRepository.java
@@ -1,0 +1,7 @@
+package com.woowacourse.matzip.repository;
+
+import com.woowacourse.matzip.domain.campus.Campus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CampusRepository extends JpaRepository<Campus, Long> {
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/repository/CategoryRepository.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.woowacourse.matzip.repository;
+
+import com.woowacourse.matzip.domain.category.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/repository/MemberRepository.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.woowacourse.matzip.repository;
+
+import com.woowacourse.matzip.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/repository/RestaurantRepository.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/repository/RestaurantRepository.java
@@ -1,0 +1,7 @@
+package com.woowacourse.matzip.repository;
+
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/repository/ReviewRepository.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.woowacourse.matzip.repository;
+
+import com.woowacourse.matzip.domain.review.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/MainView.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/MainView.java
@@ -1,0 +1,8 @@
+package com.woowacourse.matzip.ui;
+
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "/", layout = SideNavbarLayout.class)
+public class MainView extends VerticalLayout {
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/SideNavbarLayout.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/SideNavbarLayout.java
@@ -1,0 +1,73 @@
+package com.woowacourse.matzip.ui;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.applayout.AppLayout;
+import com.vaadin.flow.component.applayout.DrawerToggle;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.tabs.Tab;
+import com.vaadin.flow.component.tabs.Tabs;
+import com.vaadin.flow.dom.ThemeList;
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.flow.theme.lumo.Lumo;
+import com.woowacourse.matzip.ui.member.MemberListView;
+
+public class SideNavbarLayout extends AppLayout {
+
+    public SideNavbarLayout() {
+        H1 title = new H1("Mat Zip");
+        title.getStyle()
+                .set("font-size", "var(--lumo-font-size-l)")
+                .set("margin", "0");
+
+        addToDrawer(getTabs());
+        addToNavbar(new DrawerToggle(), title, darkModeToggleButton());
+        setPrimarySection(Section.DRAWER);
+    }
+
+    private Tabs getTabs() {
+        Tabs tabs = new Tabs();
+        tabs.add(
+                createTab(VaadinIcon.USER, "유저", MemberListView.class)
+        );
+        tabs.setOrientation(Tabs.Orientation.VERTICAL);
+        return tabs;
+    }
+
+    private Tab createTab(final VaadinIcon viewIcon, final String viewName,
+                          final Class<? extends Component> navigationTarget) {
+        RouterLink link = new RouterLink();
+        link.setRoute(navigationTarget);
+        link.add(createIcon(viewIcon), new Span(viewName));
+        return new Tab(link);
+    }
+
+    private Icon createIcon(final VaadinIcon viewIcon) {
+        Icon icon = viewIcon.create();
+        icon.getStyle()
+                .set("box-sizing", "border-box")
+                .set("margin-inline-end", "var(--lumo-space-m)")
+                .set("margin-inline-start", "var(--lumo-space-xs)")
+                .set("padding", "var(--lumo-space-xs)");
+        return icon;
+    }
+
+    private Button darkModeToggleButton() {
+        Button button = new Button(VaadinIcon.ADJUST.create(), click -> {
+            ThemeList themeList = UI.getCurrent().getElement().getThemeList();
+
+            if (themeList.contains(Lumo.DARK)) {
+                themeList.remove(Lumo.DARK);
+            } else {
+                themeList.add(Lumo.DARK);
+            }
+        });
+        button.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        return button;
+    }
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/SideNavbarLayout.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/SideNavbarLayout.java
@@ -17,6 +17,7 @@ import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.theme.lumo.Lumo;
 import com.woowacourse.matzip.ui.member.MemberListView;
 import com.woowacourse.matzip.ui.restaurant.RestaurantListView;
+import com.woowacourse.matzip.ui.review.ReviewListView;
 
 public class SideNavbarLayout extends AppLayout {
 
@@ -34,8 +35,10 @@ public class SideNavbarLayout extends AppLayout {
     private Tabs getTabs() {
         Tabs tabs = new Tabs();
         tabs.add(
+                createTab(VaadinIcon.HOME, null, MainView.class),
                 createTab(VaadinIcon.USER, "유저", MemberListView.class),
-                createTab(VaadinIcon.SHOP, "음식점", RestaurantListView.class)
+                createTab(VaadinIcon.SHOP, "음식점", RestaurantListView.class),
+                createTab(VaadinIcon.TEXT_INPUT, "리뷰", ReviewListView.class)
         );
         tabs.setOrientation(Tabs.Orientation.VERTICAL);
         return tabs;

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/SideNavbarLayout.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/SideNavbarLayout.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.dom.ThemeList;
 import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.theme.lumo.Lumo;
 import com.woowacourse.matzip.ui.member.MemberListView;
+import com.woowacourse.matzip.ui.restaurant.RestaurantListView;
 
 public class SideNavbarLayout extends AppLayout {
 
@@ -33,7 +34,8 @@ public class SideNavbarLayout extends AppLayout {
     private Tabs getTabs() {
         Tabs tabs = new Tabs();
         tabs.add(
-                createTab(VaadinIcon.USER, "유저", MemberListView.class)
+                createTab(VaadinIcon.USER, "유저", MemberListView.class),
+                createTab(VaadinIcon.SHOP, "음식점", RestaurantListView.class)
         );
         tabs.setOrientation(Tabs.Orientation.VERTICAL);
         return tabs;

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberDetailForm.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberDetailForm.java
@@ -3,26 +3,29 @@ package com.woowacourse.matzip.ui.member;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
-import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.html.H2;
-import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextField;
 
 public class MemberDetailForm extends FormLayout {
+
+    private final TextField id = new TextField("id");
+    private final TextField githubId = new TextField("github d");
+    private final TextField username = new TextField("username");
+    private final TextField profileImage = new TextField("profile image url");
+    private final TextField createdAt = new TextField("created date");
 
     public MemberDetailForm() {
         addClassName("contact-form");
 
         add(
                 new H2("멤버 상세 정보"),
-                new TextField("id"),
-                new TextField("github id"),
-                new TextField("username"),
-                new TextField("profile image url"),
-                new TextField("created date"),
+                id,
+                githubId,
+                username,
+                profileImage,
+                createdAt,
                 createButtonsLayout()
         );
     }
@@ -38,7 +41,6 @@ public class MemberDetailForm extends FormLayout {
         Button close = new Button("취소");
         close.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
         close.addClickShortcut(Key.ESCAPE);
-
 
         return new HorizontalLayout(save, delete, close);
     }

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberDetailForm.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberDetailForm.java
@@ -1,0 +1,45 @@
+package com.woowacourse.matzip.ui.member;
+
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.textfield.EmailField;
+import com.vaadin.flow.component.textfield.TextField;
+
+public class MemberDetailForm extends FormLayout {
+
+    public MemberDetailForm() {
+        addClassName("contact-form");
+
+        add(
+                new H2("멤버 상세 정보"),
+                new TextField("id"),
+                new TextField("github id"),
+                new TextField("username"),
+                new TextField("profile image url"),
+                new TextField("created date"),
+                createButtonsLayout()
+        );
+    }
+
+    private HorizontalLayout createButtonsLayout() {
+        Button save = new Button("저장");
+        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        save.addClickShortcut(Key.ENTER);
+
+        Button delete = new Button("삭제");
+        delete.addThemeVariants(ButtonVariant.LUMO_ERROR);
+
+        Button close = new Button("취소");
+        close.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        close.addClickShortcut(Key.ESCAPE);
+
+
+        return new HorizontalLayout(save, delete, close);
+    }
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
@@ -2,6 +2,9 @@ package com.woowacourse.matzip.ui.member;
 
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.data.renderer.LitRenderer;
+import com.vaadin.flow.data.renderer.LocalDateTimeRenderer;
+import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.router.Route;
 import com.woowacourse.matzip.application.AdminMemberService;
 import com.woowacourse.matzip.domain.member.Member;
@@ -22,16 +25,32 @@ public class MemberListView extends VerticalLayout {
     }
 
     private Grid<Member> createMemberGrid() {
-        Grid<Member> grid = new Grid<>();
+        Grid<Member> grid = new Grid<>(Member.class, false);
         grid.setSizeFull();
         grid.addColumn(Member::getId).setHeader("id");
         grid.addColumn(Member::getGithubId).setHeader("github id");
-        grid.addColumn(Member::getUsername).setHeader("username");
+        grid.addColumn(createMemberProfileRenderer()).setHeader("username");
         grid.addColumn(Member::getProfileImage).setHeader("profile image url");
-        grid.addColumn(Member::getCreatedAt).setHeader("created date");
+        grid.addColumn(new LocalDateTimeRenderer<>(Member::getCreatedAt, "yyyy-MM-dd hh:mm:ss"))
+                .setHeader("created date")
+                .setComparator(Member::getCreatedAt);
+
         grid.getColumns().forEach(col -> col.setAutoWidth(true));
+        grid.getColumns().forEach(col -> col.setSortable(true));
 
         grid.setItems(adminMemberService.findAll());
         return grid;
+    }
+
+    private static Renderer<Member> createMemberProfileRenderer() {
+        return LitRenderer.<Member>of(
+                "<vaadin-horizontal-layout style=\"align-items: center;\" theme=\"spacing\">"
+                        + "  <vaadin-avatar img=\"${item.profileImage}\" name=\"${item.username}\"></vaadin-avatar>"
+                        + "  <vaadin-vertical-layout style=\"line-height: var(--lumo-line-height-m);\">"
+                        + "    <span> ${item.username} </span>"
+                        + "  </vaadin-vertical-layout>"
+                        + "</vaadin-horizontal-layout>")
+                .withProperty("profileImage", Member::getProfileImage)
+                .withProperty("username", Member::getUsername);
     }
 }

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
@@ -1,6 +1,8 @@
 package com.woowacourse.matzip.ui.member;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.data.renderer.LitRenderer;
 import com.vaadin.flow.data.renderer.LocalDateTimeRenderer;
@@ -20,8 +22,19 @@ public class MemberListView extends VerticalLayout {
         setSizeFull();
 
         add(
-                createMemberGrid()
+                getContent()
         );
+    }
+
+    private Component getContent() {
+        Grid<Member> memberGrid = createMemberGrid();
+        MemberDetailForm memberForm = createMemberForm();
+        HorizontalLayout content = new HorizontalLayout(memberGrid, memberForm);
+        content.setFlexGrow(2, memberGrid);
+        content.setFlexGrow(1, memberForm);
+        content.addClassNames("content");
+        content.setSizeFull();
+        return content;
     }
 
     private Grid<Member> createMemberGrid() {
@@ -42,7 +55,7 @@ public class MemberListView extends VerticalLayout {
         return grid;
     }
 
-    private static Renderer<Member> createMemberProfileRenderer() {
+    private Renderer<Member> createMemberProfileRenderer() {
         return LitRenderer.<Member>of(
                 "<vaadin-horizontal-layout style=\"align-items: center;\" theme=\"spacing\">"
                         + "  <vaadin-avatar img=\"${item.profileImage}\" name=\"${item.username}\"></vaadin-avatar>"
@@ -52,5 +65,11 @@ public class MemberListView extends VerticalLayout {
                         + "</vaadin-horizontal-layout>")
                 .withProperty("profileImage", Member::getProfileImage)
                 .withProperty("username", Member::getUsername);
+    }
+
+    private MemberDetailForm createMemberForm() {
+        MemberDetailForm memberDetailForm = new MemberDetailForm();
+        memberDetailForm.setWidth("25em");
+        return memberDetailForm;
     }
 }

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
@@ -1,8 +1,6 @@
 package com.woowacourse.matzip.ui.member;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.data.renderer.LitRenderer;
 import com.vaadin.flow.data.renderer.LocalDateTimeRenderer;
@@ -10,8 +8,9 @@ import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.router.Route;
 import com.woowacourse.matzip.application.AdminMemberService;
 import com.woowacourse.matzip.domain.member.Member;
+import com.woowacourse.matzip.ui.SideNavbarLayout;
 
-@Route("/admin/members")
+@Route(value = "/admin/members", layout = SideNavbarLayout.class)
 public class MemberListView extends VerticalLayout {
 
     private final AdminMemberService adminMemberService;
@@ -22,19 +21,8 @@ public class MemberListView extends VerticalLayout {
         setSizeFull();
 
         add(
-                getContent()
+                createMemberGrid()
         );
-    }
-
-    private Component getContent() {
-        Grid<Member> memberGrid = createMemberGrid();
-        MemberDetailForm memberForm = createMemberForm();
-        HorizontalLayout content = new HorizontalLayout(memberGrid, memberForm);
-        content.setFlexGrow(2, memberGrid);
-        content.setFlexGrow(1, memberForm);
-        content.addClassNames("content");
-        content.setSizeFull();
-        return content;
     }
 
     private Grid<Member> createMemberGrid() {
@@ -65,11 +53,5 @@ public class MemberListView extends VerticalLayout {
                         + "</vaadin-horizontal-layout>")
                 .withProperty("profileImage", Member::getProfileImage)
                 .withProperty("username", Member::getUsername);
-    }
-
-    private MemberDetailForm createMemberForm() {
-        MemberDetailForm memberDetailForm = new MemberDetailForm();
-        memberDetailForm.setWidth("25em");
-        return memberDetailForm;
     }
 }

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
@@ -1,0 +1,37 @@
+package com.woowacourse.matzip.ui.member;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+import com.woowacourse.matzip.application.AdminMemberService;
+import com.woowacourse.matzip.domain.member.Member;
+
+@Route("/admin/members")
+public class MemberListView extends VerticalLayout {
+
+    private final AdminMemberService adminMemberService;
+
+    public MemberListView(final AdminMemberService adminMemberService) {
+        this.adminMemberService = adminMemberService;
+        addClassName("list-view");
+        setSizeFull();
+
+        add(
+                createMemberGrid()
+        );
+    }
+
+    private Grid<Member> createMemberGrid() {
+        Grid<Member> grid = new Grid<>();
+        grid.setSizeFull();
+        grid.addColumn(Member::getId).setHeader("id");
+        grid.addColumn(Member::getGithubId).setHeader("github id");
+        grid.addColumn(Member::getUsername).setHeader("username");
+        grid.addColumn(Member::getProfileImage).setHeader("profile image url");
+        grid.addColumn(Member::getCreatedAt).setHeader("created date");
+        grid.getColumns().forEach(col -> col.setAutoWidth(true));
+
+        grid.setItems(adminMemberService.findAll());
+        return grid;
+    }
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/member/MemberListView.java
@@ -10,7 +10,7 @@ import com.woowacourse.matzip.application.AdminMemberService;
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.ui.SideNavbarLayout;
 
-@Route(value = "/admin/members", layout = SideNavbarLayout.class)
+@Route(value = "/members", layout = SideNavbarLayout.class)
 public class MemberListView extends VerticalLayout {
 
     private final AdminMemberService adminMemberService;

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/restaurant/RestaurantListView.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/restaurant/RestaurantListView.java
@@ -1,0 +1,44 @@
+package com.woowacourse.matzip.ui.restaurant;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+import com.woowacourse.matzip.application.AdminRestaurantService;
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import com.woowacourse.matzip.ui.SideNavbarLayout;
+
+@Route(value = "/restaurants", layout = SideNavbarLayout.class)
+public class RestaurantListView extends VerticalLayout {
+
+    private final AdminRestaurantService adminRestaurantService;
+
+    public RestaurantListView(final AdminRestaurantService adminRestaurantService) {
+        this.adminRestaurantService = adminRestaurantService;
+        addClassName("restaurant-view");
+        setSizeFull();
+
+        add(
+                createRestaurantGrid()
+        );
+    }
+
+    private Grid<Restaurant> createRestaurantGrid() {
+        Grid<Restaurant> grid = new Grid<>(Restaurant.class, false);
+        grid.setSizeFull();
+
+        grid.addColumn(Restaurant::getId).setHeader("id");
+        grid.addColumn(Restaurant::getCategoryId).setHeader("category");
+        grid.addColumn(Restaurant::getCampusId).setHeader("campus");
+        grid.addColumn(Restaurant::getName).setHeader("name");
+        grid.addColumn(Restaurant::getAddress).setHeader("address");
+        grid.addColumn(Restaurant::getDistance).setHeader("distance");
+        grid.addColumn(Restaurant::getKakaoMapUrl).setHeader("kakao map url");
+        grid.addColumn(Restaurant::getImageUrl).setHeader("image url");
+
+        grid.getColumns().forEach(col -> col.setAutoWidth(true));
+        grid.getColumns().forEach(col -> col.setSortable(true));
+
+        grid.setItems(adminRestaurantService.findAll());
+        return grid;
+    }
+}

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/restaurant/RestaurantListView.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/restaurant/RestaurantListView.java
@@ -4,6 +4,7 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 import com.woowacourse.matzip.application.AdminRestaurantService;
+import com.woowacourse.matzip.application.response.RestaurantResponse;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
 import com.woowacourse.matzip.ui.SideNavbarLayout;
 
@@ -22,18 +23,18 @@ public class RestaurantListView extends VerticalLayout {
         );
     }
 
-    private Grid<Restaurant> createRestaurantGrid() {
-        Grid<Restaurant> grid = new Grid<>(Restaurant.class, false);
+    private Grid<RestaurantResponse> createRestaurantGrid() {
+        Grid<RestaurantResponse> grid = new Grid<>(RestaurantResponse.class, false);
         grid.setSizeFull();
 
-        grid.addColumn(Restaurant::getId).setHeader("id");
-        grid.addColumn(Restaurant::getCategoryId).setHeader("category");
-        grid.addColumn(Restaurant::getCampusId).setHeader("campus");
-        grid.addColumn(Restaurant::getName).setHeader("name");
-        grid.addColumn(Restaurant::getAddress).setHeader("address");
-        grid.addColumn(Restaurant::getDistance).setHeader("distance");
-        grid.addColumn(Restaurant::getKakaoMapUrl).setHeader("kakao map url");
-        grid.addColumn(Restaurant::getImageUrl).setHeader("image url");
+        grid.addColumn(RestaurantResponse::getId).setHeader("id");
+        grid.addColumn(RestaurantResponse::getCategoryName).setHeader("category");
+        grid.addColumn(RestaurantResponse::getCampusName).setHeader("campus");
+        grid.addColumn(RestaurantResponse::getName).setHeader("name");
+        grid.addColumn(RestaurantResponse::getAddress).setHeader("address");
+        grid.addColumn(RestaurantResponse::getDistance).setHeader("distance");
+        grid.addColumn(RestaurantResponse::getKakaoMapUrl).setHeader("kakao map url");
+        grid.addColumn(RestaurantResponse::getImageUrl).setHeader("image url");
 
         grid.getColumns().forEach(col -> col.setAutoWidth(true));
         grid.getColumns().forEach(col -> col.setSortable(true));

--- a/app-internal-api/src/main/java/com/woowacourse/matzip/ui/review/ReviewListView.java
+++ b/app-internal-api/src/main/java/com/woowacourse/matzip/ui/review/ReviewListView.java
@@ -1,0 +1,45 @@
+package com.woowacourse.matzip.ui.review;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.data.renderer.LocalDateTimeRenderer;
+import com.vaadin.flow.router.Route;
+import com.woowacourse.matzip.application.AdminReviewService;
+import com.woowacourse.matzip.application.response.ReviewResponse;
+import com.woowacourse.matzip.ui.SideNavbarLayout;
+
+@Route(value = "/reviews", layout = SideNavbarLayout.class)
+public class ReviewListView extends VerticalLayout {
+
+    private final AdminReviewService adminReviewService;
+
+    public ReviewListView(final AdminReviewService adminReviewService) {
+        this.adminReviewService = adminReviewService;
+        setSizeFull();
+
+        add(
+                createReviewGrid()
+        );
+    }
+
+    private Grid<ReviewResponse> createReviewGrid() {
+        Grid<ReviewResponse> grid = new Grid<>(ReviewResponse.class, false);
+        grid.setSizeFull();
+
+        grid.addColumn(ReviewResponse::getId).setHeader("id");
+        grid.addColumn(ReviewResponse::getWriterName).setHeader("writer");
+        grid.addColumn(ReviewResponse::getRestaurantName).setHeader("restaurant");
+        grid.addColumn(ReviewResponse::getContent).setHeader("content");
+        grid.addColumn(ReviewResponse::getRating).setHeader("rating");
+        grid.addColumn(ReviewResponse::getMenu).setHeader("menu");
+        grid.addColumn(new LocalDateTimeRenderer<>(ReviewResponse::getCreatedAt, "yyyy-MM-dd hh:mm:ss"))
+                .setHeader("created date")
+                .setComparator(ReviewResponse::getCreatedAt);
+
+        grid.getColumns().forEach(col -> col.setAutoWidth(true));
+        grid.getColumns().forEach(col -> col.setSortable(true));
+
+        grid.setItems(adminReviewService.findAll());
+        return grid;
+    }
+}

--- a/app-internal-api/src/main/resources/application.yml
+++ b/app-internal-api/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  devtools:
+    livereload:
+      enabled: true

--- a/app-internal-api/src/main/resources/application.yml
+++ b/app-internal-api/src/main/resources/application.yml
@@ -2,3 +2,16 @@ spring:
   devtools:
     livereload:
       enabled: true
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:matzip;MODE=MYSQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:

--- a/app-internal-api/src/main/resources/data.sql
+++ b/app-internal-api/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+insert into member (github_id, username, profile_image, created_at) values ('87312401', 'jayjaehunchoi', 'https://avatars.githubusercontent.com/u/87312401?v=4', current_timestamp);
+insert into member (github_id, username, profile_image, created_at) values ('43166681', 'uk960214', 'https://avatars.githubusercontent.com/u/43166681?v=4', current_timestamp);
+insert into member (github_id, username, profile_image, created_at) values ('54002105', 'nan-noo', 'https://avatars.githubusercontent.com/u/54002105?v=4', current_timestamp);
+insert into member (github_id, username, profile_image, created_at) values ('60773373', 'liswktjs', 'https://avatars.githubusercontent.com/u/60773373?v=4', current_timestamp);
+insert into member (github_id, username, profile_image, created_at) values ('69106910', 'jinyoungchoi95', 'https://avatars.githubusercontent.com/u/69106910?v=4', current_timestamp);
+insert into member (github_id, username, profile_image, created_at) values ('66253212', 'Ohzzi', 'https://avatars.githubusercontent.com/u/66253212?v=4', current_timestamp);

--- a/app-internal-api/src/main/resources/data.sql
+++ b/app-internal-api/src/main/resources/data.sql
@@ -4,3 +4,30 @@ insert into member (github_id, username, profile_image, created_at) values ('540
 insert into member (github_id, username, profile_image, created_at) values ('60773373', 'liswktjs', 'https://avatars.githubusercontent.com/u/60773373?v=4', current_timestamp);
 insert into member (github_id, username, profile_image, created_at) values ('69106910', 'jinyoungchoi95', 'https://avatars.githubusercontent.com/u/69106910?v=4', current_timestamp);
 insert into member (github_id, username, profile_image, created_at) values ('66253212', 'Ohzzi', 'https://avatars.githubusercontent.com/u/66253212?v=4', current_timestamp);
+
+insert into category (name)
+values ('한식');
+insert into category (name)
+values ('중식');
+insert into category (name)
+values ('일식');
+insert into category (name)
+values ('양식');
+insert into category (name)
+values ('카페/디저트');
+
+insert into campus (name)
+values ('잠실');
+insert into campus (name)
+values ('선릉');
+
+insert into restaurant (category_id, campus_id, name, address, distance, kakao_map_url, image_url)
+values (1, 2, '배가무닭볶음탕', '서울 강남구 선릉로86길 30 1층', 1, 'https://place.map.kakao.com/733513512', 'www.image.com');
+insert into restaurant (category_id, campus_id, name, address, distance, kakao_map_url, image_url)
+values (1, 2, '뽕나무쟁이 선릉본점', '서울 강남구 역삼로65길 31', 1, 'https://place.map.kakao.com/11190567', 'www.image.com');
+insert into restaurant (category_id, campus_id, name, address, distance, kakao_map_url, image_url)
+values (2, 2, '마담밍', '서울 강남구 선릉로86길 5-4 1층', 1, 'https://place.map.kakao.com/18283045', 'www.image.com');
+insert into restaurant (category_id, campus_id, name, address, distance, kakao_map_url, image_url)
+values (2, 2, '마담밍2', '서울 강남구 선릉로86길 5-4 2층', 1, 'https://place.map.kakao.com/18283045', 'www.image.com');
+insert into restaurant (category_id, campus_id, name, address, distance, kakao_map_url, image_url)
+values (2, 2, '마담밍3', '서울 강남구 선릉로86길 5-4 3층', 1, 'https://place.map.kakao.com/18283045', 'www.image.com');

--- a/app-internal-api/src/main/resources/schema.sql
+++ b/app-internal-api/src/main/resources/schema.sql
@@ -1,0 +1,54 @@
+drop table if exists member;
+drop table if exists restaurant;
+drop table if exists review;
+drop table if exists category;
+drop table if exists campus;
+
+CREATE TABLE member
+(
+    id            bigint       NOT NULL AUTO_INCREMENT,
+    github_id     varchar(255) NOT NULL UNIQUE,
+    username      varchar(255) NOT NULL,
+    profile_image varchar(255) NOT NULL,
+    created_at    TIMESTAMP    NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE restaurant
+(
+    id            bigint       NOT NULL AUTO_INCREMENT,
+    category_id   bigint       NOT NULL,
+    campus_id     bigint       NOT NULL,
+    name          varchar(20)  NOT NULL,
+    address       varchar(255) NOT NULL UNIQUE,
+    distance      bigint       NOT NULL,
+    kakao_map_url varchar(255) NOT NULL,
+    image_url     varchar(255) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE review
+(
+    id            bigint       NOT NULL AUTO_INCREMENT,
+    member_id     bigint       NOT NULL,
+    restaurant_id bigint       NOT NULL,
+    content       varchar(255) NULL,
+    rating        int          NOT NULL,
+    menu          varchar(20)  NOT NULL,
+    created_at    TIMESTAMP    NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE category
+(
+    id   bigint      NOT NULL AUTO_INCREMENT,
+    name varchar(10) NOT NULL UNIQUE,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE campus
+(
+    id   bigint      NOT NULL AUTO_INCREMENT,
+    name varchar(20) NOT NULL UNIQUE,
+    PRIMARY KEY (id)
+);

--- a/common/src/main/java/com/woowacourse/matzip/exception/CategoryNotFoundException.java
+++ b/common/src/main/java/com/woowacourse/matzip/exception/CategoryNotFoundException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.matzip.exception;
+
+public class CategoryNotFoundException extends RuntimeException {
+
+    public CategoryNotFoundException() {
+        super("존재하지 않는 카테고리입니다.");
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = 'matzip'
 
 include(
         "app-external-api",
+        "app-internal-api",
         "common",
         "core"
 )


### PR DESCRIPTION
## issue: #69

### 실행방법
- clone -> application 실행 -> 하단 npm install 탭나오면 클릭
- 아래와 같은 route로 페이지 이동이 진행된다면 정상작동입니다.
<img width="1604" alt="스크린샷 2022-08-27 오전 7 57 00" src="https://user-images.githubusercontent.com/69106910/187000901-b012ebb8-bcdf-4d25-91dc-5d385427ddcc.png">

- live reload : https://youngkyonyou.github.io/springboot/2021/07/07/springboot-post16.html
- 관련해서 생서된 어드민 프론트페이지도 과연 repo에 추가해야하나 싶네요. restdocs도 지금 update계속 하고 있긴한데 둘다 지금 삭제하고 배포시에만 확인할거라면 굳이 git에 올리지 않아도 생각이 듭니다. 관련해서 의견있다면 이야기부탁드려요.

### 구현 목록 리스트
- `app-internal-api` 모듈 추가
- vaadin 구축을 위한 build script 설정
- 유저, 음식점, 리뷰 전체 조회기능 추가

### `app-internal-api`
- 어드민을 위한 모듈을 추가하였습니다.
- 이전에 이야기한대로 repository에 대한 부분은 전체 구현을 마무리한 뒤 core 모듈로 통합할 예정입니다.
- 설정관련해서 이야기할 부분이 있는데, application은 현재 두가지로 `external`과 `internal`이 두개가 있습니다. 이 둘이 중복되는 설정값(ex spring-boot-web)이 많아 공통적으로 나중에 처리해두어야할 것 같네요.

### vaadin 구축을 위한 build script
- 기본설정만 해두었습니다.
- vaadin docs에서 제공되는 default 설정값만 추가하였으며 spring-boot starter에서도 vaadin에 대한 추가를 진행해주어 거기서 크게 수정없이 된 점 참고 부탁드립니다. (https://vaadin.com/docs/latest/guide/start/gradle)

### response
- view 페이지들에서 사용할때 vaadin 공식 페이지나 우테코 지원플랫폼 등에서는 entity를 반환하는 모습을 볼 수 있습니다.
- 다만 저희 프로젝트 내에서는 간접참조되어있는 부분이 많아 바로바로 어드민페이지에서 보고싶은(ex 리뷰 조회 시 식당 이름) 정보들이 가시적이지를 않아 response를 반환하도록 통일하였습니다.

### test
- admin에서는 정말 간단한 api만 구현될 예정인데요. 테스트를 진행해야하느냐에 대한 의문이 있습니다. 의견 부탁드려요 ㅎㅎ...

### 화면 구조
- 화면 구조는 크게 아래와 같습니다.
    - 구성되는 페이지 (View로 끝나는 클래스)
    - 왼쪽과 상단의 사이드바 (SideNavbarLayout)
#### SideNavbarLayout
- sidenavbarlayout은 왼쪽 네비바와 본문 상단 헤더에 해당합니다.
- `getTabs`에서 왼쪽 네이바에서 이동할 수 있는 탭을 추가할 수 있으므로 코드 참고 부탁드립니다.
- 각각의 View 클래스에서 페이지를 만들 때 해당 클래스를 항상 추가해주어야 해당 route 페이지에서 네비바를 볼 수 있습니다. 따라서 `@Route(value = "/reviews", layout = SideNavbarLayout.class)`와 같이 새로운 view를 만드는 경우 layout으로 추가해주어야합니다.

#### View
- MainView는 의미없는 빈페이지로 두었으며 아마 admin사용에 필요한 documentation을 적어두지않을까 싶네요.
- `Grid`로 필요한 표에 대한 설정들을 모두 채워넣을 수 있습니다. (특이사항으로는 LocalDateTime에 대한 format지원을 해주지 않아 직접 설정해주어야합니다.)
- `MemberDetailForm`는 현재 사용하지 않는 클래스이며, 차후 detailform으로써 추가할 예정입니다 (현재 pr에서 추가하기엔 볼륨이 너무 큼)

### 추가 작업이 필요한 부분
- data initializer의 경우 일단 sql로 추가해두었습니다. (local에서만 테스트할 수 있도록 다른 이슈에서 해결해두겠습니다)
- `app-external-api`와 마찬가지로 jar 배포에 대한 준비는 되어있지 않습니다.