### PR TITLE
feat: 리뷰 수정, 삭제 api를 구현한다.

### DIFF
--- a/app-external-api/src/docs/asciidoc/review.adoc
+++ b/app-external-api/src/docs/asciidoc/review.adoc
@@ -12,3 +12,7 @@ operation::reviewes/list[snippets='http-request,http-response']
 === 리뷰 수정
 
 operation::reviewes/update[snippets='http-request,http-response']
+
+=== 리뷰 삭제
+
+operation::reviewes/delete[snippets='http-request,http-response']

--- a/app-external-api/src/docs/asciidoc/review.adoc
+++ b/app-external-api/src/docs/asciidoc/review.adoc
@@ -8,3 +8,7 @@ operation::reviewes/create[snippets='http-request,http-response']
 === 리뷰 조회
 
 operation::reviewes/list[snippets='http-request,http-response']
+
+=== 리뷰 수정
+
+operation::reviewes/update[snippets='http-request,http-response']

--- a/app-external-api/src/main/java/com/woowacourse/auth/config/AuthConfig.java
+++ b/app-external-api/src/main/java/com/woowacourse/auth/config/AuthConfig.java
@@ -38,8 +38,9 @@ public class AuthConfig implements WebMvcConfigurer {
     private HandlerInterceptor loginInterceptor() {
         return new PathMatcherInterceptor(loginInterceptor)
                 .excludePathPattern("/**", PathMethod.OPTIONS)
-                .includePathPattern(REVIEWS_PATH, PathMethod.ANY)
-                .excludePathPattern(REVIEWS_PATH, PathMethod.GET);
+                .includePathPattern(REVIEWS_PATH, PathMethod.POST)
+                .includePathPattern(REVIEWS_PATH + "/*", PathMethod.PUT)
+                .includePathPattern(REVIEWS_PATH + "/*", PathMethod.DELETE);
     }
 
     private HandlerInterceptor loginOrNotInterceptor() {

--- a/app-external-api/src/main/java/com/woowacourse/auth/config/AuthConfig.java
+++ b/app-external-api/src/main/java/com/woowacourse/auth/config/AuthConfig.java
@@ -15,6 +15,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class AuthConfig implements WebMvcConfigurer {
 
+    private static final String REVIEWS_PATH = "/api/restaurants/*/reviews";
+
     private final LoginInterceptor loginInterceptor;
     private final LoginCheckerInterceptor loginCheckerInterceptor;
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
@@ -36,12 +38,13 @@ public class AuthConfig implements WebMvcConfigurer {
     private HandlerInterceptor loginInterceptor() {
         return new PathMatcherInterceptor(loginInterceptor)
                 .excludePathPattern("/**", PathMethod.OPTIONS)
-                .includePathPattern("/api/restaurants/*/reviews", PathMethod.POST);
+                .includePathPattern(REVIEWS_PATH, PathMethod.ANY)
+                .excludePathPattern(REVIEWS_PATH, PathMethod.GET);
     }
 
     private HandlerInterceptor loginOrNotInterceptor() {
         return new PathMatcherInterceptor(loginCheckerInterceptor)
-                .includePathPattern("/api/restaurants/*/reviews", PathMethod.GET);
+                .includePathPattern(REVIEWS_PATH, PathMethod.GET);
     }
 
     @Override

--- a/app-external-api/src/main/java/com/woowacourse/matzip/application/ReviewService.java
+++ b/app-external-api/src/main/java/com/woowacourse/matzip/application/ReviewService.java
@@ -7,7 +7,9 @@ import com.woowacourse.matzip.domain.member.MemberRepository;
 import com.woowacourse.matzip.domain.review.Review;
 import com.woowacourse.matzip.domain.review.ReviewRepository;
 import com.woowacourse.matzip.exception.MemberNotFoundException;
+import com.woowacourse.matzip.exception.ReviewNotFoundException;
 import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
+import com.woowacourse.matzip.presentation.request.ReviewUpdateRequest;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
@@ -36,11 +38,28 @@ public class ReviewService {
         reviewRepository.save(review);
     }
 
-    public ReviewsResponse findPageByRestaurantId(final String githubId, final Long restaurantId, final Pageable pageable) {
+    public ReviewsResponse findPageByRestaurantId(final String githubId, final Long restaurantId,
+                                                  final Pageable pageable) {
         Slice<Review> page = reviewRepository.findPageByRestaurantIdOrderByIdDesc(restaurantId, pageable);
         List<ReviewResponse> reviewResponses = page.stream()
                 .map(review -> ReviewResponse.of(review, review.isWriter(githubId)))
                 .collect(Collectors.toList());
         return new ReviewsResponse(page.hasNext(), reviewResponses);
+    }
+
+    @Transactional
+    public void updateReview(final String githubId,
+                             final Long reviewId,
+                             final ReviewUpdateRequest reviewUpdateRequest) {
+        Member member = memberRepository.findMemberByGithubId(githubId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(ReviewNotFoundException::new);
+
+        review.update(member.getGithubId(),
+                reviewUpdateRequest.getContent(),
+                reviewUpdateRequest.getRating(),
+                reviewUpdateRequest.getMenu());
     }
 }

--- a/app-external-api/src/main/java/com/woowacourse/matzip/presentation/ReviewController.java
+++ b/app-external-api/src/main/java/com/woowacourse/matzip/presentation/ReviewController.java
@@ -4,6 +4,7 @@ import com.woowacourse.auth.support.AuthenticationPrincipal;
 import com.woowacourse.matzip.application.ReviewService;
 import com.woowacourse.matzip.application.response.ReviewsResponse;
 import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
+import com.woowacourse.matzip.presentation.request.ReviewUpdateRequest;
 import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,5 +40,14 @@ public class ReviewController {
                                                        final Pageable pageable,
                                                        @AuthenticationPrincipal final String githubId) {
         return ResponseEntity.ok(reviewService.findPageByRestaurantId(githubId, restaurantId, pageable));
+    }
+
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<Void> updateReview(@PathVariable final Long restaurantId,
+                                             @PathVariable final Long reviewId,
+                                             @AuthenticationPrincipal final String githubId,
+                                             @RequestBody @Valid final ReviewUpdateRequest reviewUpdateRequest) {
+        reviewService.updateReview(githubId, reviewId, reviewUpdateRequest);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/app-external-api/src/main/java/com/woowacourse/matzip/presentation/ReviewController.java
+++ b/app-external-api/src/main/java/com/woowacourse/matzip/presentation/ReviewController.java
@@ -9,6 +9,7 @@ import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,6 +49,14 @@ public class ReviewController {
                                              @AuthenticationPrincipal final String githubId,
                                              @RequestBody @Valid final ReviewUpdateRequest reviewUpdateRequest) {
         reviewService.updateReview(githubId, reviewId, reviewUpdateRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Void> deleteReview(@PathVariable final Long restaurantId,
+                                             @PathVariable final Long reviewId,
+                                             @AuthenticationPrincipal final String githubId) {
+        reviewService.deleteReview(githubId, reviewId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/app-external-api/src/main/java/com/woowacourse/matzip/presentation/request/ReviewUpdateRequest.java
+++ b/app-external-api/src/main/java/com/woowacourse/matzip/presentation/request/ReviewUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.woowacourse.matzip.presentation.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ReviewUpdateRequest {
+
+    @NotNull(message = "리뷰 내용은 null이 들어올 수 없습니다.")
+    private String content;
+    private int rating;
+    @NotNull(message = "리뷰 메뉴는 null이 들어올 수 없습니다.")
+    private String menu;
+
+    private ReviewUpdateRequest() {
+    }
+
+    public ReviewUpdateRequest(final String content, final int rating, final String menu) {
+        this.content = content;
+        this.rating = rating;
+        this.menu = menu;
+    }
+}

--- a/app-external-api/src/main/java/com/woowacourse/support/exception/GlobalControllerAdvice.java
+++ b/app-external-api/src/main/java/com/woowacourse/support/exception/GlobalControllerAdvice.java
@@ -11,6 +11,7 @@ import com.woowacourse.matzip.exception.InvalidReviewException;
 import com.woowacourse.matzip.exception.InvalidSortConditionException;
 import com.woowacourse.matzip.exception.MemberNotFoundException;
 import com.woowacourse.matzip.exception.RestaurantNotFoundException;
+import com.woowacourse.matzip.exception.ReviewNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -43,7 +44,8 @@ public class GlobalControllerAdvice {
     @ExceptionHandler({
             CampusNotFoundException.class,
             MemberNotFoundException.class,
-            RestaurantNotFoundException.class
+            RestaurantNotFoundException.class,
+            ReviewNotFoundException.class
     })
     public ResponseEntity<ErrorResponse> notFoundExceptionHandler(final RuntimeException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.from(e));

--- a/app-external-api/src/main/java/com/woowacourse/support/exception/GlobalControllerAdvice.java
+++ b/app-external-api/src/main/java/com/woowacourse/support/exception/GlobalControllerAdvice.java
@@ -4,6 +4,7 @@ import com.woowacourse.auth.exception.GithubAccessException;
 import com.woowacourse.auth.exception.InvalidTokenException;
 import com.woowacourse.auth.exception.TokenNotFoundException;
 import com.woowacourse.matzip.exception.CampusNotFoundException;
+import com.woowacourse.matzip.exception.ForbiddenException;
 import com.woowacourse.matzip.exception.InvalidCategoryException;
 import com.woowacourse.matzip.exception.InvalidLengthException;
 import com.woowacourse.matzip.exception.InvalidReviewException;
@@ -32,6 +33,11 @@ public class GlobalControllerAdvice {
     })
     public ResponseEntity<ErrorResponse> tokenExceptionHandler(final RuntimeException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse.from(e));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> forbiddenException(final ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.from(e));
     }
 
     @ExceptionHandler({

--- a/app-external-api/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
+++ b/app-external-api/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
@@ -143,7 +143,7 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     private void 리뷰_삭제에_성공한다(final ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
     private void 리뷰_작성에_실패한다(final ExtractableResponse<Response> response) {

--- a/app-external-api/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
+++ b/app-external-api/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.acceptance;
 
 import static com.woowacourse.acceptance.AuthAcceptanceTest.로그인_토큰;
+import static com.woowacourse.acceptance.support.RestAssuredRequest.httpDeleteRequest;
 import static com.woowacourse.acceptance.support.RestAssuredRequest.httpGetRequest;
 import static com.woowacourse.acceptance.support.RestAssuredRequest.httpPostRequest;
 import static com.woowacourse.acceptance.support.RestAssuredRequest.httpPutRequest;
@@ -41,6 +42,11 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
                                                           final ReviewUpdateRequest reviewUpdateRequest) {
         return httpPutRequest("/api/restaurants/" + restaurantId + "/reviews/" + reviewId, accessToken,
                 reviewUpdateRequest);
+    }
+
+    private static ExtractableResponse<Response> 리뷰_삭제_요청(final Long restaurantId, final Long reviewId,
+                                                          final String accessToken) {
+        return httpDeleteRequest("/api/restaurants/" + restaurantId + "/reviews/" + reviewId, accessToken);
     }
 
     @Test
@@ -117,8 +123,27 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         리뷰가_수정됨(response, updatedResponse);
     }
 
+    @Test
+    void 리뷰가_삭제됨() {
+        String accessToken = 로그인_토큰();
+        ReviewCreateRequest request = new ReviewCreateRequest("맛있네요.", 4, "무닭볶음탕 (중)");
+
+        리뷰_생성_요청(식당_ID, accessToken, request);
+        ReviewResponse reviewResponse = 리뷰_조회_요청(식당_ID, accessToken, 0, 1)
+                .as(ReviewsResponse.class)
+                .getReviews()
+                .get(0);
+
+        ExtractableResponse<Response> response = 리뷰_삭제_요청(식당_ID, reviewResponse.getId(), accessToken);
+        리뷰_삭제에_성공한다(response);
+    }
+
     private void 리뷰_작성에_성공한다(final ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    private void 리뷰_삭제에_성공한다(final ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
 
     private void 리뷰_작성에_실패한다(final ExtractableResponse<Response> response) {

--- a/app-external-api/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
+++ b/app-external-api/src/test/java/com/woowacourse/acceptance/ReviewAcceptanceTest.java
@@ -30,12 +30,17 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         return httpGetRequest("/api/restaurants/" + restaurantId + "/reviews?page=" + page + "&size=" + size);
     }
 
-    private static ExtractableResponse<Response> 리뷰_조회_요청(final Long restaurantId, final String accessToken, final int page, final int size) {
-        return httpGetRequest("/api/restaurants/" + restaurantId + "/reviews?page=" + page + "&size=" + size, accessToken);
+    private static ExtractableResponse<Response> 리뷰_조회_요청(final Long restaurantId, final String accessToken,
+                                                          final int page, final int size) {
+        return httpGetRequest("/api/restaurants/" + restaurantId + "/reviews?page=" + page + "&size=" + size,
+                accessToken);
     }
 
-    private static ExtractableResponse<Response> 리뷰_수정_요청(final Long restaurantId, final Long reviewId, final String accessToken, final ReviewUpdateRequest reviewUpdateRequest) {
-        return httpPutRequest("/api/restaurants/" + restaurantId + "/reviews/" + reviewId, accessToken, reviewUpdateRequest);
+    private static ExtractableResponse<Response> 리뷰_수정_요청(final Long restaurantId, final Long reviewId,
+                                                          final String accessToken,
+                                                          final ReviewUpdateRequest reviewUpdateRequest) {
+        return httpPutRequest("/api/restaurants/" + restaurantId + "/reviews/" + reviewId, accessToken,
+                reviewUpdateRequest);
     }
 
     @Test
@@ -139,7 +144,9 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     private void 리뷰가_수정됨(final ExtractableResponse<Response> response, final ReviewResponse updatedResponse) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
-                () -> assertThat(updatedResponse).usingRecursiveComparison().isEqualTo(new ReviewUpdateRequest("맛이 있어요.", 5, "무닭볶음탕 (대)"))
+                () -> assertThat(updatedResponse.getContent()).isEqualTo("맛이 있어요."),
+                () -> assertThat(updatedResponse.getRating()).isEqualTo(5),
+                () -> assertThat(updatedResponse.getMenu()).isEqualTo("무닭볶음탕 (대)")
         );
     }
 }

--- a/app-external-api/src/test/java/com/woowacourse/acceptance/support/RestAssuredRequest.java
+++ b/app-external-api/src/test/java/com/woowacourse/acceptance/support/RestAssuredRequest.java
@@ -36,7 +36,6 @@ public class RestAssuredRequest {
                 .extract();
     }
 
-
     public static ExtractableResponse<Response> httpPutRequest(final String url,
                                                                final String accessToken,
                                                                 final Object request) {
@@ -46,6 +45,17 @@ public class RestAssuredRequest {
                 .header("Authorization", "Bearer " + accessToken)
                 .body(request)
                 .when().put(url)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> httpDeleteRequest(final String url,
+                                                               final String accessToken) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + accessToken)
+                .when().delete(url)
                 .then().log().all()
                 .extract();
     }

--- a/app-external-api/src/test/java/com/woowacourse/acceptance/support/RestAssuredRequest.java
+++ b/app-external-api/src/test/java/com/woowacourse/acceptance/support/RestAssuredRequest.java
@@ -35,4 +35,20 @@ public class RestAssuredRequest {
                 .then().log().all()
                 .extract();
     }
+
+
+    public static ExtractableResponse<Response> httpPutRequest(final String url,
+                                                               final String accessToken,
+                                                                final Object request) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(request)
+                .when().put(url)
+                .then().log().all()
+                .extract();
+    }
+
+
 }

--- a/app-external-api/src/test/java/com/woowacourse/document/ReviewDocumentation.java
+++ b/app-external-api/src/test/java/com/woowacourse/document/ReviewDocumentation.java
@@ -54,4 +54,17 @@ public class ReviewDocumentation extends Documentation {
                 .apply(document("reviewes/update"))
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
+
+    @Test
+    void 리뷰를_삭제한다() {
+        doNothing().when(reviewService).deleteReview(anyString(), anyLong());
+
+        docsGiven
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer jwt.token.here")
+                .when().delete("/api/restaurants/1/reviews/1")
+                .then().log().all()
+                .apply(document("reviewes/delete"))
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
 }

--- a/app-external-api/src/test/java/com/woowacourse/document/ReviewDocumentation.java
+++ b/app-external-api/src/test/java/com/woowacourse/document/ReviewDocumentation.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
+import com.woowacourse.matzip.presentation.request.ReviewUpdateRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -38,5 +39,19 @@ public class ReviewDocumentation extends Documentation {
                 .then().log().all()
                 .apply(document("reviewes/list"))
                 .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 리뷰를_수정한다() {
+        doNothing().when(reviewService).updateReview(anyString(), anyLong(), any(ReviewUpdateRequest.class));
+
+        docsGiven
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer jwt.token.here")
+                .body(new ReviewUpdateRequest("맛있네요.", 4, "무닭볶음탕 (중)"))
+                .when().put("/api/restaurants/1/reviews/1")
+                .then().log().all()
+                .apply(document("reviewes/update"))
+                .statusCode(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/app-external-api/src/test/java/com/woowacourse/matzip/application/ReviewServiceTest.java
+++ b/app-external-api/src/test/java/com/woowacourse/matzip/application/ReviewServiceTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.woowacourse.matzip.application.response.ReviewResponse;
 import com.woowacourse.matzip.application.response.ReviewsResponse;
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.member.MemberRepository;
@@ -15,6 +16,7 @@ import com.woowacourse.matzip.domain.restaurant.Restaurant;
 import com.woowacourse.matzip.domain.restaurant.RestaurantRepository;
 import com.woowacourse.matzip.exception.MemberNotFoundException;
 import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
+import com.woowacourse.matzip.presentation.request.ReviewUpdateRequest;
 import com.woowacourse.support.SpringServiceTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,6 +88,31 @@ public class ReviewServiceTest {
         assertAll(
                 () -> assertThat(page1.getReviews()).extracting("updatable").containsExactly(false, true),
                 () -> assertThat(page2.getReviews()).extracting("updatable").containsExactly(true, true)
+        );
+    }
+
+    @Test
+    void 리뷰를_수정한다() {
+        Member member = memberRepository.save(ORI.toMember());
+        Restaurant restaurant = restaurantRepository.findAll().get(0);
+        reviewService.createReview(member.getGithubId(), restaurant.getId(), reviewCreateRequest());
+
+        Long reviewId = reviewService.findPageByRestaurantId(member.getGithubId(), restaurant.getId(), PageRequest.of(0, 1))
+                .getReviews()
+                .get(0)
+                .getId();
+
+        ReviewUpdateRequest reviewUpdateRequest = new ReviewUpdateRequest("내용", 5, "메뉴");
+        reviewService.updateReview(member.getGithubId(), reviewId, reviewUpdateRequest);
+
+        ReviewResponse reviewResponse = reviewService.findPageByRestaurantId(member.getGithubId(), restaurant.getId(),
+                        PageRequest.of(0, 1))
+                .getReviews()
+                .get(0);
+        assertAll(
+                () -> assertThat(reviewResponse.getContent()).isEqualTo("내용"),
+                () -> assertThat(reviewResponse.getRating()).isEqualTo(5),
+                () -> assertThat(reviewResponse.getMenu()).isEqualTo("메뉴")
         );
     }
 }

--- a/app-external-api/src/test/java/com/woowacourse/matzip/application/ReviewServiceTest.java
+++ b/app-external-api/src/test/java/com/woowacourse/matzip/application/ReviewServiceTest.java
@@ -14,6 +14,7 @@ import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.member.MemberRepository;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
 import com.woowacourse.matzip.domain.restaurant.RestaurantRepository;
+import com.woowacourse.matzip.domain.review.ReviewRepository;
 import com.woowacourse.matzip.exception.MemberNotFoundException;
 import com.woowacourse.matzip.presentation.request.ReviewCreateRequest;
 import com.woowacourse.matzip.presentation.request.ReviewUpdateRequest;
@@ -27,6 +28,9 @@ public class ReviewServiceTest {
 
     @Autowired
     private ReviewService reviewService;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
 
     @Autowired
     private RestaurantRepository restaurantRepository;
@@ -114,5 +118,20 @@ public class ReviewServiceTest {
                 () -> assertThat(reviewResponse.getRating()).isEqualTo(5),
                 () -> assertThat(reviewResponse.getMenu()).isEqualTo("메뉴")
         );
+    }
+
+    @Test
+    void 리뷰를_삭제한다() {
+        Member member = memberRepository.save(ORI.toMember());
+        Restaurant restaurant = restaurantRepository.findAll().get(0);
+        reviewService.createReview(member.getGithubId(), restaurant.getId(), reviewCreateRequest());
+
+        Long reviewId = reviewService.findPageByRestaurantId(member.getGithubId(), restaurant.getId(), PageRequest.of(0, 1))
+                .getReviews()
+                .get(0)
+                .getId();
+
+        reviewService.deleteReview(member.getGithubId(), reviewId);
+        assertThat(reviewRepository.findById(reviewId).isEmpty()).isTrue();
     }
 }

--- a/common/src/main/java/com/woowacourse/matzip/exception/ForbiddenException.java
+++ b/common/src/main/java/com/woowacourse/matzip/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.matzip.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(final String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/com/woowacourse/matzip/exception/ReviewNotFoundException.java
+++ b/common/src/main/java/com/woowacourse/matzip/exception/ReviewNotFoundException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.matzip.exception;
+
+public class ReviewNotFoundException extends RuntimeException {
+
+    public ReviewNotFoundException() {
+        super("존재하지 않는 리뷰입니다.");
+    }
+}

--- a/core/src/main/java/com/woowacourse/matzip/domain/review/Review.java
+++ b/core/src/main/java/com/woowacourse/matzip/domain/review/Review.java
@@ -1,6 +1,7 @@
 package com.woowacourse.matzip.domain.review;
 
 import com.woowacourse.matzip.domain.member.Member;
+import com.woowacourse.matzip.exception.ForbiddenException;
 import com.woowacourse.matzip.exception.InvalidReviewException;
 import com.woowacourse.matzip.support.LengthValidator;
 import java.time.LocalDateTime;
@@ -77,6 +78,25 @@ public class Review {
     private void validateRating(final int rating) {
         if (rating < MIN_SCORE || rating > MAX_SCORE) {
             throw new InvalidReviewException(String.format("리뷰 점수는 %d점부터 %d점까지만 가능합니다.", MIN_SCORE, MAX_SCORE));
+        }
+    }
+
+    public void update(final String githubId,
+                       final String content,
+                       final int rating,
+                       final String menu) {
+        validateOwner(githubId);
+        validateRating(rating);
+        LengthValidator.checkStringLength(menu, MAX_MENU_LENGTH, "메뉴의 이름");
+        LengthValidator.checkStringLength(content, MAX_CONTENT_LENGTH, "리뷰 내용");
+        this.content = content;
+        this.rating = rating;
+        this.menu = menu;
+    }
+
+    private void validateOwner(final String githubId) {
+        if (!isWriter(githubId)) {
+            throw new ForbiddenException("리뷰를 업데이트 할 권한이 없습니다.");
         }
     }
 

--- a/core/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
+++ b/core/src/test/java/com/woowacourse/matzip/domain/review/ReviewTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.matzip.domain.member.Member;
+import com.woowacourse.matzip.exception.ForbiddenException;
 import com.woowacourse.matzip.exception.InvalidLengthException;
 import com.woowacourse.matzip.exception.InvalidReviewException;
 import java.time.LocalDateTime;
@@ -67,4 +68,57 @@ public class ReviewTest {
         Review review = new Review(1L, member, 1L, "리뷰 내용", 3, "메뉴", LocalDateTime.now());
         assertThat(review.isWriter(githubId)).isFalse();
     }
+
+    @Test
+    void 업데이트_권한이_없어_실패한다() {
+        Member huni = new Member(1L, "1", "huni", "image.png");
+        Member ori = new Member(2L, "2", "ori", "image.png");
+        Review review = new Review(1L, huni, 1L, "리뷰 내용", 3, "메뉴", LocalDateTime.now());
+
+        assertThatThrownBy(
+                () -> review.update(ori.getGithubId(), "리뷰 내용 2", 4, "메뉴 2")
+        )
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("리뷰를 업데이트 할 권한이 없습니다.");
+    }
+
+    @Test
+    void 업데이트시_리뷰_내용_길이제한() {
+        String content = IntStream.rangeClosed(1, 256)
+                .mapToObj(index -> "a")
+                .collect(Collectors.joining());
+        Member huni = new Member(1L, "1", "huni", "image.png");
+        Review review = new Review(1L, huni, 1L, "리뷰 내용", 3, "메뉴", LocalDateTime.now());
+
+        assertThatThrownBy(
+                () -> review.update(huni.getGithubId(), content, 4, "메뉴")
+        )
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage("리뷰 내용은(는) 길이가 255 이하의 값만 입력할 수 있습니다.");
+    }
+
+    @Test
+    void 업데이트시_리뷰_메뉴_길이제한() {
+        String menu = "리뷰의 메뉴 이름이 이렇게 길 수 없습니다.";
+        Member huni = new Member(1L, "1", "huni", "image.png");
+        Review review = new Review(1L, huni, 1L, "리뷰 내용", 3, "메뉴", LocalDateTime.now());
+
+        assertThatThrownBy(
+                () -> review.update(huni.getGithubId(), "리뷰 내용", 4, menu)
+        )
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage("메뉴의 이름은(는) 길이가 20 이하의 값만 입력할 수 있습니다.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 6})
+    void 업데이트시_별점_범위제한인_경우_예외발생(final int score) {
+        Member huni = new Member(1L, "1", "huni", "image.png");
+        Review review = new Review(1L, huni, 1L, "리뷰 내용", 3, "메뉴", LocalDateTime.now());
+
+        assertThatThrownBy(() -> review.update(huni.getGithubId(), "리뷰 내용", score, "메뉴 2"))
+                .isInstanceOf(InvalidReviewException.class)
+                .hasMessage("리뷰 점수는 1점부터 5점까지만 가능합니다.");
+    }
+
 }


### PR DESCRIPTION
## issue: #62 

## as-is
- 리뷰 수정, 삭제 api가 없음

## to-be
`PUT /api/restaurants/{restaurantId}/reviews/{reviewId}`
content: String
rating: NUMBER
menu: String

`DELETE /api/restaurants/{restaurantId}/reviews/{reviewId}`


### 건의 사항

현재 deleteReview 코드가 절차적으로 작성되어 있습니다.
삭제라는 도메인 로직을 응용 레이어에서 갖고 있어요. 이런 경우 저는 도메인에 delete 메서드를 만들고 delete를 실행할 수 있는 [도메인 서비스](https://www.manty.co.kr/bbs/detail/develop?id=146) 를 만들어 사용하는 편입니다. 하지만 현재 멀티 모듈 구조상 repository를 api 모듈에서 참조하면 도메인에 해당 도메인 서비스를 넣을 수 없고(의존성이 api -> core 이기 때문) 도메인 서비스가 코어에 있을 경우 repository를 참조할 수 가 없습니다.

따라서 핵심이 되는 Repository는 core로 이동하여 도메인 서비스를 만들 수 있도록 하면 응용 계층에서의 도메인 지식을 제거할 수 있을 것 같습니다.