### PR TITLE
feat: 식당 추가 요청 도메인을 구현한다

### DIFF
--- a/common/src/main/java/com/woowacourse/matzip/exception/AlreadyRegisteredException.java
+++ b/common/src/main/java/com/woowacourse/matzip/exception/AlreadyRegisteredException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.matzip.exception;
+
+public class AlreadyRegisteredException extends RuntimeException {
+
+    public AlreadyRegisteredException() {
+        super("이미 등록 완료된 음식점 요청입니다.");
+    }
+}

--- a/common/src/main/java/com/woowacourse/matzip/exception/ForbiddenException.java
+++ b/common/src/main/java/com/woowacourse/matzip/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.matzip.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(final String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/woowacourse/matzip/domain/member/Member.java
+++ b/core/src/main/java/com/woowacourse/matzip/domain/member/Member.java
@@ -69,11 +69,11 @@ public class Member {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Member)) {
             return false;
         }
         Member member = (Member) o;
-        return Objects.equals(id, member.id);
+        return Objects.equals(id, member.getId());
     }
 
     @Override

--- a/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
+++ b/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
@@ -1,0 +1,67 @@
+package com.woowacourse.matzip.domain.restaurant;
+
+import com.woowacourse.matzip.support.LengthValidator;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "restaurant_request")
+@Getter
+public class RestaurantRequest {
+
+    private static final int MAX_NAME_LENGTH = 20;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "category_id", nullable = false)
+    private Long categoryId;
+
+    @Column(name = "campus_id", nullable = false)
+    private Long campusId;
+
+    @Column(name = "name", length = MAX_NAME_LENGTH, nullable = false)
+    private String name;
+
+    @Column(name = "registered", nullable = false)
+    private boolean registered;
+
+    protected RestaurantRequest() {
+    }
+
+    @Builder
+    public RestaurantRequest(final Long id, final Long categoryId, final Long campusId, final String name,
+                             final boolean registered) {
+        LengthValidator.checkStringLength(name, MAX_NAME_LENGTH, "식당 이름");
+        this.id = id;
+        this.categoryId = categoryId;
+        this.campusId = campusId;
+        this.name = name;
+        this.registered = registered;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final RestaurantRequest that = (RestaurantRequest) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
+++ b/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.matzip.domain.restaurant;
 
+import com.woowacourse.matzip.exception.AlreadyRegisteredException;
 import com.woowacourse.matzip.support.LengthValidator;
 import java.util.Objects;
 import javax.persistence.Column;
@@ -52,6 +53,17 @@ public class RestaurantRequest {
         this.categoryId = updateRequest.categoryId;
         this.campusId = updateRequest.campusId;
         this.name = updateRequest.name;
+    }
+
+    public void register() {
+        validateNotRegistered();
+        registered = true;
+    }
+
+    private void validateNotRegistered() {
+        if (registered) {
+            throw new AlreadyRegisteredException();
+        }
     }
 
     @Override

--- a/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
+++ b/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
@@ -67,13 +67,13 @@ public class RestaurantRequest {
         this.name = updateRequest.name;
     }
 
-    private void validateWriter(final String githubId) {
+    public void validateWriter(final String githubId) {
         if (!isWriter(githubId)) {
             throw new ForbiddenException("식당 추가 요청을 수정할 권한이 없습니다.");
         }
     }
 
-    public boolean isWriter(final @Nullable String githubId) {
+    private boolean isWriter(final @Nullable String githubId) {
         return member.isSameGithubId(githubId);
     }
 

--- a/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
+++ b/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
@@ -1,13 +1,17 @@
 package com.woowacourse.matzip.domain.restaurant;
 
+import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.exception.AlreadyRegisteredException;
 import com.woowacourse.matzip.support.LengthValidator;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,6 +36,10 @@ public class RestaurantRequest {
     @Column(name = "name", length = MAX_NAME_LENGTH, nullable = false)
     private String name;
 
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
     @Column(name = "registered", nullable = false)
     private boolean registered;
 
@@ -40,12 +48,13 @@ public class RestaurantRequest {
 
     @Builder
     public RestaurantRequest(final Long id, final Long categoryId, final Long campusId, final String name,
-                             final boolean registered) {
+                             final Member member, final boolean registered) {
         LengthValidator.checkStringLength(name, MAX_NAME_LENGTH, "식당 이름");
         this.id = id;
         this.categoryId = categoryId;
         this.campusId = campusId;
         this.name = name;
+        this.member = member;
         this.registered = registered;
     }
 

--- a/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
+++ b/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
@@ -2,6 +2,7 @@ package com.woowacourse.matzip.domain.restaurant;
 
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.exception.AlreadyRegisteredException;
+import com.woowacourse.matzip.exception.ForbiddenException;
 import com.woowacourse.matzip.support.LengthValidator;
 import java.util.Objects;
 import javax.persistence.Column;
@@ -15,6 +16,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.lang.Nullable;
 
 @Entity
 @Table(name = "restaurant_request")
@@ -58,10 +60,21 @@ public class RestaurantRequest {
         this.registered = registered;
     }
 
-    public void update(final RestaurantRequest updateRequest) {
+    public void update(final RestaurantRequest updateRequest, final String githubId) {
+        validateWriter(githubId);
         this.categoryId = updateRequest.categoryId;
         this.campusId = updateRequest.campusId;
         this.name = updateRequest.name;
+    }
+
+    private void validateWriter(final String githubId) {
+        if (!isWriter(githubId)) {
+            throw new ForbiddenException("식당 추가 요청을 수정할 권한이 없습니다.");
+        }
+    }
+
+    public boolean isWriter(final @Nullable String githubId) {
+        return member.isSameGithubId(githubId);
     }
 
     public void register() {

--- a/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
+++ b/core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequest.java
@@ -48,6 +48,12 @@ public class RestaurantRequest {
         this.registered = registered;
     }
 
+    public void update(final RestaurantRequest updateRequest) {
+        this.categoryId = updateRequest.categoryId;
+        this.campusId = updateRequest.campusId;
+        this.name = updateRequest.name;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
+++ b/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
@@ -1,6 +1,8 @@
 package com.woowacourse.matzip.domain.restaurant;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.matzip.exception.InvalidLengthException;
 import org.junit.jupiter.api.Test;
@@ -16,5 +18,47 @@ class RestaurantRequestTest {
                 .build())
                 .isInstanceOf(InvalidLengthException.class)
                 .hasMessage("식당 이름은(는) 길이가 20 이하의 값만 입력할 수 있습니다.");
+    }
+
+    @Test
+    void 식당_추가_요청을_수정한다() {
+        RestaurantRequest target = RestaurantRequest.builder()
+                .id(1L)
+                .categoryId(1L)
+                .campusId(1L)
+                .name("식당")
+                .build();
+
+        RestaurantRequest updateRequest = RestaurantRequest.builder()
+                .categoryId(2L)
+                .campusId(2L)
+                .name("변경된 식당 이름")
+                .build();
+
+        target.update(updateRequest);
+
+        assertAll(
+                () -> assertThat(target.getId()).isEqualTo(1L),
+                () -> assertThat(target).usingRecursiveComparison()
+                        .ignoringFields("id")
+                        .isEqualTo(updateRequest)
+        );
+    }
+
+    @Test
+    void 식당_추가_요청은_id를_바꾸지_않는다() {
+        RestaurantRequest target = RestaurantRequest.builder()
+                .id(1L)
+                .name("식당")
+                .build();
+
+        RestaurantRequest updateRequest = RestaurantRequest.builder()
+                .id(2L)
+                .name("식당")
+                .build();
+
+        target.update(updateRequest);
+
+        assertThat(target.getId()).isOne();
     }
 }

--- a/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
+++ b/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
@@ -1,0 +1,20 @@
+package com.woowacourse.matzip.domain.restaurant;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.matzip.exception.InvalidLengthException;
+import org.junit.jupiter.api.Test;
+
+class RestaurantRequestTest {
+
+    @Test
+    void 식당_추가_요청_생성_시_이름_길이_제한() {
+        String name = "식당의 이름이 이렇게 길 수 없습니다.";
+
+        assertThatThrownBy(() -> RestaurantRequest.builder()
+                .name(name)
+                .build())
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessage("식당 이름은(는) 길이가 20 이하의 값만 입력할 수 있습니다.");
+    }
+}

--- a/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
+++ b/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.exception.AlreadyRegisteredException;
 import com.woowacourse.matzip.exception.InvalidLengthException;
 import org.junit.jupiter.api.Test;
@@ -23,11 +24,16 @@ class RestaurantRequestTest {
 
     @Test
     void 식당_추가_요청을_수정한다() {
+        Member member = Member.builder()
+                .githubId("githubId")
+                .build();
+
         RestaurantRequest target = RestaurantRequest.builder()
                 .id(1L)
                 .categoryId(1L)
                 .campusId(1L)
                 .name("식당")
+                .member(member)
                 .build();
 
         RestaurantRequest updateRequest = RestaurantRequest.builder()
@@ -36,21 +42,26 @@ class RestaurantRequestTest {
                 .name("변경된 식당 이름")
                 .build();
 
-        target.update(updateRequest);
+        target.update(updateRequest, "githubId");
 
         assertAll(
                 () -> assertThat(target.getId()).isEqualTo(1L),
                 () -> assertThat(target).usingRecursiveComparison()
-                        .ignoringFields("id")
+                        .ignoringFields("id", "member")
                         .isEqualTo(updateRequest)
         );
     }
 
     @Test
     void 식당_추가_요청은_id를_바꾸지_않는다() {
+        Member member = Member.builder()
+                .githubId("githubId")
+                .build();
+
         RestaurantRequest target = RestaurantRequest.builder()
                 .id(1L)
                 .name("식당")
+                .member(member)
                 .build();
 
         RestaurantRequest updateRequest = RestaurantRequest.builder()
@@ -58,7 +69,7 @@ class RestaurantRequestTest {
                 .name("식당")
                 .build();
 
-        target.update(updateRequest);
+        target.update(updateRequest, "githubId");
 
         assertThat(target.getId()).isOne();
     }

--- a/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
+++ b/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.exception.AlreadyRegisteredException;
+import com.woowacourse.matzip.exception.ForbiddenException;
 import com.woowacourse.matzip.exception.InvalidLengthException;
 import org.junit.jupiter.api.Test;
 
@@ -72,6 +73,28 @@ class RestaurantRequestTest {
         target.update(updateRequest, "githubId");
 
         assertThat(target.getId()).isOne();
+    }
+
+    @Test
+    void 작성자가_아니면_식당_추가_요청을_수정할_수_없다() {
+        Member member = Member.builder()
+                .githubId("githubId")
+                .build();
+
+        RestaurantRequest target = RestaurantRequest.builder()
+                .id(1L)
+                .name("식당")
+                .member(member)
+                .build();
+
+        RestaurantRequest updateRequest = RestaurantRequest.builder()
+                .id(2L)
+                .name("식당")
+                .build();
+
+        assertThatThrownBy(() -> target.update(updateRequest, "wrongGithubId"))
+                .isExactlyInstanceOf(ForbiddenException.class)
+                .hasMessage("식당 추가 요청을 수정할 권한이 없습니다.");
     }
 
     @Test

--- a/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
+++ b/core/src/test/java/com/woowacourse/matzip/domain/restaurant/RestaurantRequestTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.matzip.exception.AlreadyRegisteredException;
 import com.woowacourse.matzip.exception.InvalidLengthException;
 import org.junit.jupiter.api.Test;
 
@@ -60,5 +61,26 @@ class RestaurantRequestTest {
         target.update(updateRequest);
 
         assertThat(target.getId()).isOne();
+    }
+
+    @Test
+    void 식당_추가_요청을_등록_상태로_바꾼다() {
+        RestaurantRequest target = RestaurantRequest.builder()
+                .name("식당")
+                .build();
+
+        target.register();
+
+        assertThat(target.isRegistered()).isTrue();
+    }
+
+    @Test
+    void 이미_등록된_식당_추가_요청은_등록_상태로_바꿀_수_없다() {
+        RestaurantRequest target = RestaurantRequest.builder()
+                .name("식당")
+                .registered(true)
+                .build();
+
+        assertThatThrownBy(target::register).isExactlyInstanceOf(AlreadyRegisteredException.class);
     }
 }


### PR DESCRIPTION
## issue: closes #74 

## as-is
- 식당 추가 요청 도메인이 존재하지 않음

## to-be
- 식당 추가 요청 도메인 구현
- 카테고리 id, 캠퍼스 id, 멤버(작성자), 등록여부를 가짐
- 수정 시에는 반드시 작성자 검증을 하도록 구현
- 등록 시(요청 생성이 아님, 요청을 바탕으로 실제 식당을 등록할 때 `registered` 값이 변경되는 것을 의미)에는 admin이 등록할 것이므로 작성자 검증 로직이 포함되어 있지 않음
  - admin에서 구현할 때 관리자 검증을 따로 하면 될 듯
- 기존에 존재하던 `Member` 클래스가 지연 로딩으로 로딩되는데, equals가 프록시를 고려하지 않아서 해당 부분 수정
