### PR TITLE
fix: 식당 추가 요청 조회 응답에 github id가 아닌 username을 노출

### DIFF
--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantDemandResponse.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantDemandResponse.java
@@ -27,13 +27,13 @@ public class RestaurantDemandResponse {
     }
 
     public static RestaurantDemandResponse of(final RestaurantDemand restaurantDemand, final String githubId) {
-        String authorGithubId = restaurantDemand.getMember()
-                .getGithubId();
+        String username = restaurantDemand.getMember()
+                .getUsername();
         return new RestaurantDemandResponse(
                 restaurantDemand.getId(),
                 restaurantDemand.getCategoryId(),
                 restaurantDemand.getName(),
-                authorGithubId,
+                username,
                 restaurantDemand.isWriter(githubId),
                 restaurantDemand.isRegistered()
         );


### PR DESCRIPTION
## issue: closes #92 

## as-is
- RestaurantDemand 생성 시 member.githubId가 주입됨

## to-be
- member.githubId 대신 member.username을 넣도록 수정
