### PR TITLE
feat: Graceful shutdown 적용

### DIFF
--- a/matzip-app-external-api/src/main/java/com/woowacourse/support/config/async/AsyncEventConfig.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/support/config/async/AsyncEventConfig.java
@@ -1,4 +1,4 @@
-package com.woowacourse.support.config;
+package com.woowacourse.support.config.async;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +15,7 @@ public class AsyncEventConfig {
         threadPoolTaskExecutor.setCorePoolSize(10);
         threadPoolTaskExecutor.setMaxPoolSize(20);
         threadPoolTaskExecutor.setQueueCapacity(25);
+        threadPoolTaskExecutor.setWaitForTasksToCompleteOnShutdown(true);
         threadPoolTaskExecutor.initialize();
         return threadPoolTaskExecutor;
     }

--- a/matzip-app-external-api/src/main/java/com/woowacourse/support/config/async/ShutdownEventListener.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/support/config/async/ShutdownEventListener.java
@@ -1,0 +1,26 @@
+package com.woowacourse.support.config.async;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShutdownEventListener implements ApplicationListener<ContextClosedEvent> {
+
+    private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
+
+    public ShutdownEventListener(final ApplicationContext applicationContext) {
+        this.threadPoolTaskExecutor = (ThreadPoolTaskExecutor) applicationContext.getBean("asyncTaskExecutor");
+    }
+
+    @Override
+    public void onApplicationEvent(ContextClosedEvent event) {
+        final int activeCount = threadPoolTaskExecutor.getActiveCount();
+
+        if (activeCount > 0) {
+            threadPoolTaskExecutor.setAwaitTerminationMillis(15000);
+        }
+    }
+}

--- a/matzip-app-external-api/src/main/resources/application.yml
+++ b/matzip-app-external-api/src/main/resources/application.yml
@@ -5,5 +5,9 @@ spring:
     open-in-view: false
   profiles:
     include: auth,prod
+  lifecycle:
+    timeout-per-shutdown-phase: 15s
 server:
   port: 8080
+  shutdown: graceful
+


### PR DESCRIPTION
## issue: #139 

## as-is
- Shutdonw 시,
    - 동기 스레드에서 진행 중인 작업이 바로 종료된다. (Hard shutdown)
    - 비동기 스레드에서 진행 중인 작업이 바로 종료된다. (Hard shutdown)

## to-be
- Shutdown 시,
    - 동기 스레드에서 진행 중인 작업을 모두 마친 후 종료한다. (Graceful shutdown / 최대 15초 대기)
        - `matzip-app-external-api/src/main/resources/application.yml` 수정
    - 비동기 스레드에서 진행 중인 작업을 모두 마친 후 종료한다. (Graceful shutdown / 최대 15초 대기)
        - `matzip-app-external-api/src/main/java/com/woowacourse/support/config/async` 패키지 내부에 관련 설정 클래스 구현