### PR TITLE
chore: jdk 17로 업데이트

### DIFF
--- a/.github/workflows/sonar-cloud-analysis-build.yml
+++ b/.github/workflows/sonar-cloud-analysis-build.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '2.7.5' apply(false)
     id 'io.spring.dependency-management' version '1.1.0' apply(false)
-    id 'org.asciidoctor.convert' version '2.4.0' apply(false)
+    id 'org.asciidoctor.jvm.convert' version '2.4.0' apply(false)
     id 'java-library'
     id 'jacoco'
     id "org.sonarqube" version "3.4.0.2513" apply(false)
@@ -13,7 +13,7 @@ allprojects {
 
     group = 'com.woowacourse'
     version = '0.0.1-SNAPSHOT'
-    sourceCompatibility = '11'
+    sourceCompatibility = '17'
 
     repositories {
         mavenCentral()
@@ -24,12 +24,13 @@ subprojects {
     apply plugin: 'jacoco'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
-    apply plugin: 'org.asciidoctor.convert'
+    apply plugin: 'org.asciidoctor.jvm.convert'
 
     configurations {
         compileOnly {
             extendsFrom annotationProcessor
         }
+        asciidoctorExtensions
     }
 
     dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/matzip-app-external-api/build.gradle
+++ b/matzip-app-external-api/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation 'io.rest-assured:spring-mock-mvc:4.4.0'
 
     // rest-docs
-    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.6.RELEASE'
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
 


### PR DESCRIPTION
## issue: #192

## as-is
- java 11과 springboot 2.7.5 사용

## to-be
- java 17부터 순착적으로 적용, ~~springboot 3.2.2로 업그레이드~~
- gradle 버전 상향 ~~및 restassured, jakarta 등의 의존성 수정~~

### java 17 변경사항에 따른 추가 수정

dto class를 record로 수정하는 등의 변경이 필요할까요?


### 오류 상황 (jdk 17만 적용했을 땐 발생하지 않음)

<img width="1040" alt="image" src="https://github.com/The-Fellowship-of-the-matzip/mat.zip-back/assets/109793396/33c47568-d9db-44e4-bb5b-3092946d7388">

~~빠른 시일내에 해결해보겠습니다~~