### PR TITLE
springboot 3.1.8 적용 및 asciidoctor 설정 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '3.1.8' apply(false)
     id 'io.spring.dependency-management' version '1.1.0' apply(false)
-    id 'org.asciidoctor.jvm.convert' version '2.4.0' apply(false)
+    id 'org.asciidoctor.jvm.convert' version '3.3.2' apply(false)
     id 'java-library'
     id 'jacoco'
     id "org.sonarqube" version "3.4.0.2513" apply(false)

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.0.13' apply(false)
+    id 'org.springframework.boot' version '3.1.8' apply(false)
     id 'io.spring.dependency-management' version '1.1.0' apply(false)
     id 'org.asciidoctor.jvm.convert' version '2.4.0' apply(false)
     id 'java-library'

--- a/matzip-app-external-api/build.gradle
+++ b/matzip-app-external-api/build.gradle
@@ -43,6 +43,7 @@ test {
 
 asciidoctor {
     inputs.dir snippetsDir
+    configurations 'asciidoctorExtensions'
     dependsOn test
 }
 

--- a/matzip-app-external-api/build.gradle
+++ b/matzip-app-external-api/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // rest-assured
-    testImplementation 'io.rest-assured:rest-assured:5.3.0'
-    testImplementation 'io.rest-assured:spring-mock-mvc:5.3.0'
+    testImplementation 'io.rest-assured:rest-assured:5.3.2'
+    testImplementation 'io.rest-assured:spring-mock-mvc:5.3.2'
 
     // rest-docs
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'


### PR DESCRIPTION
## issue: #192

## as-is
- 3.0.13 GA버전 사용
- api 명세 페이지 접속시 404 발생

## to-be
- 3.1.x 버전대 GA 버전인 3.1.8 적용
- asciidoctor 버전 업그레이드 및 gradle 설정 변경
