### PR TITLE
chore: asciidoc gradle 설정 변경

### DIFF
--- a/matzip-app-external-api/build.gradle
+++ b/matzip-app-external-api/build.gradle
@@ -50,7 +50,7 @@ asciidoctor {
 task createDocument(type: Copy) {
     dependsOn asciidoctor
 
-    from file("build/asciidoc/html5/index.html")
+    from file("build/docs/asciidoc/index.html")
     into file("src/main/resources/static")
 }
 

--- a/matzip-app-external-api/src/docs/asciidoc/index.adoc
+++ b/matzip-app-external-api/src/docs/asciidoc/index.adoc
@@ -3,14 +3,15 @@
 :toc: left
 :toclevels: 2
 :sectlinks:
+:prefix: src/docs/asciidoc
 
 == Mat-Zip
 
-include::auth.adoc[]
-include::campus.adoc[]
-include::category.adoc[]
-include::restaurant.adoc[]
-include::review.adoc[]
-include::restaurantDemand.adoc[]
-include::bookmark.adoc[]
-include::mypage.adoc[]
+include::{prefix}/auth.adoc[]
+include::{prefix}/campus.adoc[]
+include::{prefix}/category.adoc[]
+include::{prefix}/restaurant.adoc[]
+include::{prefix}/review.adoc[]
+include::{prefix}/restaurantDemand.adoc[]
+include::{prefix}/bookmark.adoc[]
+include::{prefix}/mypage.adoc[]


### PR DESCRIPTION
## issue: #194

## as-is
- 이전 버전의 asciidoc 경로를 사용하고 있어서 index.html이 옮겨지지 않아 404 발생

## to-be
- 변경된 bulid/docs/asciidoc 경로로 수정해서 정상적으로 static 파일로 옮겨지는 것 확인 
