### PR TITLE
chore: springboot 3.2.3 및 actuator 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.1.8' apply(false)
+    id 'org.springframework.boot' version '3.2.3' apply(false)
     id 'io.spring.dependency-management' version '1.1.0' apply(false)
     id 'org.asciidoctor.jvm.convert' version '3.3.2' apply(false)
     id 'java-library'

--- a/matzip-app-external-api/build.gradle
+++ b/matzip-app-external-api/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.20.56')
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:aws-crt-client'
+
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 ext {


### PR DESCRIPTION
## issue: #194

## as-is
- springboot 3.1.8 버전 사용

## to-be
- springboot ga 버전인 3.2.3 으로 업그레이드
- 모니터링 구축을 위한 actuator 의존성 추가
