### PR TITLE
chore: prometheus 의존성 추가

### DIFF
--- a/matzip-app-external-api/build.gradle
+++ b/matzip-app-external-api/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 ext {


### PR DESCRIPTION
## issue: #201

## as-is
- 서버 모니터링 필요

## to-be
- 모니터링을 위한 prometheus 의존성 추가
- endpoint 세부 설정은 submodule에 되어있습니다