### PR TITLE
feat: 식당 검색 필터링 옵션에 거리 가까운 순과 좋아요 순을 추가한다.

### DIFF
--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/BookmarkService.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/BookmarkService.java
@@ -21,8 +21,8 @@ public class BookmarkService {
     private final RestaurantRepository restaurantRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public BookmarkService(MemberRepository memberRepository, RestaurantRepository restaurantRepository,
-                           BookmarkRepository bookmarkRepository) {
+    public BookmarkService(final MemberRepository memberRepository, final RestaurantRepository restaurantRepository,
+                           final BookmarkRepository bookmarkRepository) {
         this.memberRepository = memberRepository;
         this.restaurantRepository = restaurantRepository;
         this.bookmarkRepository = bookmarkRepository;

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -32,10 +32,13 @@ public class RestaurantService {
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public RestaurantService(RestaurantRepository restaurantRepository,
-                             RestaurantQueryRepository restaurantQueryRepository,
-                             ReviewRepository reviewRepository, MemberRepository memberRepository,
-                             BookmarkRepository bookmarkRepository) {
+    public RestaurantService(
+            final RestaurantRepository restaurantRepository,
+            final RestaurantQueryRepository restaurantQueryRepository,
+            final ReviewRepository reviewRepository,
+            final MemberRepository memberRepository,
+            final BookmarkRepository bookmarkRepository
+    ) {
         this.restaurantRepository = restaurantRepository;
         this.restaurantQueryRepository = restaurantQueryRepository;
         this.reviewRepository = reviewRepository;
@@ -43,16 +46,20 @@ public class RestaurantService {
         this.bookmarkRepository = bookmarkRepository;
     }
 
-    public RestaurantTitlesResponse findByCampusIdAndCategoryId(final String githubId, final String sortCondition,
-                                                                final Long campusId, final Long categoryId,
-                                                                final Pageable pageable) {
+    public RestaurantTitlesResponse findByCampusIdAndCategoryId(
+            final String githubId,
+            final String sortCondition,
+            final Long campusId,
+            final Long categoryId,
+            final Pageable pageable
+    ) {
         String restaurantFindQuery = RestaurantFindQueryFactory.from(sortCondition);
         Slice<Restaurant> restaurants = restaurantQueryRepository.findPageByCampusIdAndCategoryId(restaurantFindQuery,
                 campusId, categoryId, pageable);
         return toRestaurantTitlesResponse(githubId, restaurants);
     }
 
-    private RestaurantTitlesResponse toRestaurantTitlesResponse(final String githubId, Slice<Restaurant> page) {
+    private RestaurantTitlesResponse toRestaurantTitlesResponse(final String githubId, final Slice<Restaurant> page) {
         List<RestaurantTitleResponse> restaurantTitleResponses = page.stream()
                 .map(restaurant -> toResponseTitleResponse(githubId, restaurant))
                 .collect(Collectors.toList());
@@ -65,8 +72,7 @@ public class RestaurantService {
         return new RestaurantTitleResponse(restaurant, rating, isBookmarked(githubId, restaurant.getId()));
     }
 
-    public List<RestaurantTitleResponse> findRandomsByCampusId(final String githubId, final Long campusId,
-                                                               final int size) {
+    public List<RestaurantTitleResponse> findRandomsByCampusId(final String githubId, final Long campusId, final int size) {
         return restaurantRepository.findRandomsByCampusId(campusId, size)
                 .stream()
                 .map(restaurant -> toResponseTitleResponse(githubId, restaurant))
@@ -92,10 +98,12 @@ public class RestaurantService {
                 .isPresent();
     }
 
-    public RestaurantTitlesResponse findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(final String githubId,
-                                                                                              final Long campusId,
-                                                                                              final String name,
-                                                                                              final Pageable pageable) {
+    public RestaurantTitlesResponse findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(
+            final String githubId,
+            final Long campusId,
+            final String name,
+            final Pageable pageable
+    ) {
         Pageable pageableById = toIdDescSortPageable(pageable);
         return toRestaurantTitlesResponse(
                 githubId,
@@ -107,7 +115,7 @@ public class RestaurantService {
         return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), SortCondition.DEFAULT.getValue());
     }
 
-    public List<RestaurantTitleResponse> findBookmarkedRestaurants(String githubId) {
+    public List<RestaurantTitleResponse> findBookmarkedRestaurants(final String githubId) {
         Member member = memberRepository.findMemberByGithubId(githubId)
                 .orElseThrow(MemberNotFoundException::new);
         return member.getBookmarks()

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantFindQueryFactory.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantFindQueryFactory.java
@@ -1,5 +1,6 @@
 package com.woowacourse.matzip.infrastructure.restaurant;
 
+import com.woowacourse.matzip.domain.bookmark.Bookmark;
 import com.woowacourse.matzip.exception.InvalidSortConditionException;
 import java.util.Arrays;
 import lombok.Getter;
@@ -7,15 +8,21 @@ import lombok.Getter;
 @Getter
 public enum RestaurantFindQueryFactory {
 
-    ORDER_BY_RATING_DESC("RATING", "select r from Restaurant r "
-            + "where r.campusId = :campusId and r.categoryId = :categoryId "
-            + "order by r.reviewRatingAverage desc"),
-    ORDER_BY_NAME_ASC("SPELL", "select r from Restaurant r "
-            + "where r.campusId = :campusId and r.categoryId = :categoryId "
-            + "order by r.name"),
-    ORDER_BY_ID_DESC("DEFAULT", "select r from Restaurant r "
-            + "where (r.campusId = :campusId) and (:categoryId is null or r.categoryId = :categoryId) "
-            + "order by r.id desc"),
+    ORDER_BY_RATING_DESC("RATING", """
+            select r from Restaurant r
+            where r.campusId = :campusId and r.categoryId = :categoryId
+            order by r.reviewRatingAverage desc
+            """),
+    ORDER_BY_NAME_ASC("SPELL", """
+            select r from Restaurant r
+            where r.campusId = :campusId and r.categoryId = :categoryId
+            order by r.name
+            """),
+    ORDER_BY_ID_DESC("DEFAULT", """
+            select r from Restaurant r
+            where (r.campusId = :campusId) and (:categoryId is null or r.categoryId = :categoryId)
+            order by r.id desc
+            """),
     ORDER_BY_DISTANCE_ASC("DISTANCE", """
             select r from Restaurant r
             where r.campusId = :campusId and r.categoryId = :categoryId
@@ -33,12 +40,12 @@ public enum RestaurantFindQueryFactory {
     private final String key;
     private final String query;
 
-    RestaurantFindQueryFactory(String key, String query) {
+    RestaurantFindQueryFactory(final String key, final String query) {
         this.key = key;
         this.query = query;
     }
 
-    public static String from(String sortCondition) {
+    public static String from(final String sortCondition) {
         return Arrays.stream(values())
                 .filter(condition -> condition.key.equalsIgnoreCase(sortCondition))
                 .findAny()

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantFindQueryFactory.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantFindQueryFactory.java
@@ -19,7 +19,7 @@ public enum RestaurantFindQueryFactory {
     ORDER_BY_DISTANCE_ASC("DISTANCE", """
             select r from Restaurant r
             where r.campusId = :campusId and r.categoryId = :categoryId
-            order by r.distance
+            order by r.distance, r.name asc
             """),
     ORDER_BY_BOOKMARK_COUNT_DESC("BOOKMARK", """
             select r from Restaurant r

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantFindQueryFactory.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantFindQueryFactory.java
@@ -21,6 +21,13 @@ public enum RestaurantFindQueryFactory {
             where r.campusId = :campusId and r.categoryId = :categoryId
             order by r.distance
             """),
+    ORDER_BY_BOOKMARK_COUNT_DESC("BOOKMARK", """
+            select r from Restaurant r
+            left join Bookmark b on b.restaurant = r
+            where r.campusId = :campusId and r.categoryId = :categoryId
+            group by r
+            order by count(b) desc, r.name asc
+            """),
     ;
 
     private final String key;

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantFindQueryFactory.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantFindQueryFactory.java
@@ -16,6 +16,11 @@ public enum RestaurantFindQueryFactory {
     ORDER_BY_ID_DESC("DEFAULT", "select r from Restaurant r "
             + "where (r.campusId = :campusId) and (:categoryId is null or r.categoryId = :categoryId) "
             + "order by r.id desc"),
+    ORDER_BY_DISTANCE_ASC("DISTANCE", """
+            select r from Restaurant r
+            where r.campusId = :campusId and r.categoryId = :categoryId
+            order by r.distance
+            """),
     ;
 
     private final String key;

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantQueryRepository.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantQueryRepository.java
@@ -34,11 +34,11 @@ public class RestaurantQueryRepository {
         return new SliceImpl<>(restaurants, pageable, hasNext);
     }
 
-    private int calculateStartIndex(Pageable pageable) {
+    private int calculateStartIndex(final Pageable pageable) {
         return pageable.getPageNumber() * pageable.getPageSize();
     }
 
-    private boolean isHasNext(Pageable pageable, List<Restaurant> restaurants) {
+    private boolean isHasNext(final Pageable pageable, final List<Restaurant> restaurants) {
         return restaurants.size() == pageable.getPageSize() + 1;
     }
 }

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/presentation/BookmarkController.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/presentation/BookmarkController.java
@@ -21,15 +21,19 @@ public class BookmarkController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createBookmark(@PathVariable final Long restaurantId,
-                                               @AuthenticationPrincipal final String githubId) {
+    public ResponseEntity<Void> createBookmark(
+            @PathVariable final Long restaurantId,
+            @AuthenticationPrincipal final String githubId
+    ) {
         bookmarkService.createBookmark(githubId, restaurantId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteBookmark(@PathVariable final Long restaurantId,
-                                               @AuthenticationPrincipal final String githubId) {
+    public ResponseEntity<Void> deleteBookmark(
+            @PathVariable final Long restaurantId,
+            @AuthenticationPrincipal final String githubId
+    ) {
         bookmarkService.deleteBookmark(githubId, restaurantId);
         return ResponseEntity.noContent().build();
     }

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
@@ -25,27 +25,33 @@ public class RestaurantController {
     }
 
     @GetMapping("/campuses/{campusId}/restaurants")
-    public ResponseEntity<RestaurantTitlesResponse> showPage(@PathVariable final Long campusId,
-                                                             @AuthenticationPrincipal final String githubId,
-                                                             @RequestParam(required = false) final Long categoryId,
-                                                             @RequestParam(value = "filter", defaultValue = "DEFAULT") final String filterName,
-                                                             final Pageable pageable) {
+    public ResponseEntity<RestaurantTitlesResponse> showPage(
+            @PathVariable final Long campusId,
+            @AuthenticationPrincipal final String githubId,
+            @RequestParam(required = false) final Long categoryId,
+            @RequestParam(value = "filter", defaultValue = "DEFAULT") final String filterName,
+            final Pageable pageable
+    ) {
         return ResponseEntity.ok(
                 restaurantService.findByCampusIdAndCategoryId(githubId, filterName, campusId, categoryId, pageable));
     }
 
     @GetMapping("/campuses/{campusId}/restaurants/random")
-    public ResponseEntity<List<RestaurantTitleResponse>> showRandoms(@PathVariable final Long campusId,
-                                                                     @AuthenticationPrincipal final String githubId,
-                                                                     @RequestParam final int size) {
+    public ResponseEntity<List<RestaurantTitleResponse>> showRandoms(
+            @PathVariable final Long campusId,
+            @AuthenticationPrincipal final String githubId,
+            @RequestParam final int size
+    ) {
         return ResponseEntity.ok(restaurantService.findRandomsByCampusId(githubId, campusId, size));
     }
 
     @GetMapping("/campuses/{campusId}/restaurants/search")
-    public ResponseEntity<RestaurantTitlesResponse> searchRestaurantsPage(@PathVariable final Long campusId,
-                                                                          @AuthenticationPrincipal final String githubId,
-                                                                          @RequestParam final String name,
-                                                                          final Pageable pageable) {
+    public ResponseEntity<RestaurantTitlesResponse> searchRestaurantsPage(
+            @PathVariable final Long campusId,
+            @AuthenticationPrincipal final String githubId,
+            @RequestParam final String name,
+            final Pageable pageable
+    ) {
         return ResponseEntity.ok(
                 restaurantService.findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(
                         githubId,
@@ -63,7 +69,8 @@ public class RestaurantController {
 
     @GetMapping("/restaurants/bookmarks")
     public ResponseEntity<List<RestaurantTitleResponse>> showBookmarkedRestaurants(
-            @AuthenticationPrincipal final String githubId) {
+            @AuthenticationPrincipal final String githubId
+    ) {
         return ResponseEntity.ok(restaurantService.findBookmarkedRestaurants(githubId));
     }
 }

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -126,7 +126,7 @@ class RestaurantServiceTest {
     }
 
     @Test
-    void 캠퍼스id와_카테고리id가_일치하는_식당을_가까운_거리순으로_페이징해서_반환한다() {
+    void 캠퍼스id와_카테고리id가_일치하는_식당을_가까운_거리순_가나다순으로_페이징해서_반환한다() {
         Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당1", "주소1", 5);
         Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당2", "주소2", 7);
         Restaurant restaurant3 = createTestRestaurant(1L, 1L, "식당3", "주소3", 6);
@@ -141,7 +141,7 @@ class RestaurantServiceTest {
     }
 
     @Test
-    void 캠퍼스id와_카테고리id가_일치하는_식당을_찜수가_많은순으로_페이징해서_반환한다() {
+    void 캠퍼스id와_카테고리id가_일치하는_식당을_찜수가_많은순_가나다순으로_페이징해서_반환한다() {
         Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당1", "주소1");
         Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당2", "주소2");
         Restaurant restaurant3 = createTestRestaurant(1L, 1L, "식당3", "주소3");

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -122,6 +122,22 @@ class RestaurantServiceTest {
     }
 
     @Test
+    void 캠퍼스id와_카테고리id가_일치하는_식당을_가까운_거리순으로_페이징해서_반환한다() {
+        Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당1", "주소1", 5);
+        Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당2", "주소2", 7);
+        Restaurant restaurant3 = createTestRestaurant(1L, 1L, "식당3", "주소3", 6);
+        restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3));
+
+        RestaurantTitlesResponse response = restaurantService.findByCampusIdAndCategoryId(null, "DISTANCE", 1L, 1L,
+                PageRequest.of(0, 3));
+
+        assertThat(response.getRestaurants()).hasSize(3)
+                .extracting("id")
+                .containsExactly(restaurant1.getId(), restaurant3.getId(), restaurant2.getId());
+    }
+
+
+    @Test
     void 무작위로_지정한_캠퍼스의_지정한_개수의_식당_목록을_조회한다() {
         List<RestaurantTitleResponse> responses = restaurantService.findRandomsByCampusId(null, 2L, 2);
 

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -1,5 +1,7 @@
 package com.woowacourse.matzip.application;
 
+import static com.woowacourse.matzip.MemberFixtures.HUNI;
+import static com.woowacourse.matzip.MemberFixtures.ORI;
 import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestMember;
 import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestRestaurant;
 import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestReview;
@@ -27,6 +29,8 @@ class RestaurantServiceTest {
 
     @Autowired
     private RestaurantService restaurantService;
+    @Autowired
+    private BookmarkService bookmarkService;
     @Autowired
     private MemberRepository memberRepository;
     @Autowired
@@ -136,6 +140,27 @@ class RestaurantServiceTest {
                 .containsExactly(restaurant1.getId(), restaurant3.getId(), restaurant2.getId());
     }
 
+    @Test
+    void 캠퍼스id와_카테고리id가_일치하는_식당을_찜수가_많은순으로_페이징해서_반환한다() {
+        Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당1", "주소1");
+        Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당2", "주소2");
+        Restaurant restaurant3 = createTestRestaurant(1L, 1L, "식당3", "주소3");
+        restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3));
+
+        Member ori = memberRepository.save(ORI.toMember());
+        Member huni = memberRepository.save(HUNI.toMember());
+        bookmarkService.createBookmark(ori.getGithubId(), restaurant1.getId());
+        bookmarkService.createBookmark(ori.getGithubId(), restaurant2.getId());
+        bookmarkService.createBookmark(huni.getGithubId(), restaurant2.getId());
+        bookmarkService.createBookmark(ori.getGithubId(), restaurant3.getId());
+
+        RestaurantTitlesResponse response = restaurantService.findByCampusIdAndCategoryId(null, "BOOKMARK", 1L, 1L,
+                PageRequest.of(0, 3));
+
+        assertThat(response.getRestaurants()).hasSize(3)
+                .extracting("id")
+                .containsExactly(restaurant2.getId(), restaurant1.getId(), restaurant3.getId());
+    }
 
     @Test
     void 무작위로_지정한_캠퍼스의_지정한_개수의_식당_목록을_조회한다() {

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantQueryRepositoryTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantQueryRepositoryTest.java
@@ -1,8 +1,12 @@
 package com.woowacourse.matzip.infrastructure.restaurant;
 
+import static com.woowacourse.matzip.MemberFixtures.HUNI;
+import static com.woowacourse.matzip.MemberFixtures.ORI;
+import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestBookmark;
 import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestMember;
 import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestRestaurant;
 import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestReview;
+import static com.woowacourse.matzip.infrastructure.restaurant.RestaurantFindQueryFactory.ORDER_BY_BOOKMARK_COUNT_DESC;
 import static com.woowacourse.matzip.infrastructure.restaurant.RestaurantFindQueryFactory.ORDER_BY_DISTANCE_ASC;
 import static com.woowacourse.matzip.infrastructure.restaurant.RestaurantFindQueryFactory.ORDER_BY_ID_DESC;
 import static com.woowacourse.matzip.infrastructure.restaurant.RestaurantFindQueryFactory.ORDER_BY_NAME_ASC;
@@ -10,6 +14,7 @@ import static com.woowacourse.matzip.infrastructure.restaurant.RestaurantFindQue
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.matzip.domain.bookmark.BookmarkRepository;
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.member.MemberRepository;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
@@ -39,6 +44,8 @@ public class RestaurantQueryRepositoryTest {
     private MemberRepository memberRepository;
     @Autowired
     private ReviewRepository reviewRepository;
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
 
     @Test
     void 캠퍼스id가_일치하는_식당을_최신순으로_페이징해서_반환한다() {
@@ -124,6 +131,27 @@ public class RestaurantQueryRepositoryTest {
                 PageRequest.of(0, 3));
 
         assertThat(page).containsExactly(restaurant1, restaurant3, restaurant2);
+    }
+
+    @Test
+    void 캠퍼스id와_카테고리id가_일치하는_식당을_찜수가_많은순으로_페이징해서_반환한다() {
+        Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당1", "주소1");
+        Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당2", "주소2");
+        Restaurant restaurant3 = createTestRestaurant(1L, 1L, "식당3", "주소3");
+        restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3));
+
+        Member ori = memberRepository.save(ORI.toMember());
+        Member huni = memberRepository.save(HUNI.toMember());
+        bookmarkRepository.save(createTestBookmark(ori, restaurant1));
+        bookmarkRepository.save(createTestBookmark(ori, restaurant2));
+        bookmarkRepository.save(createTestBookmark(huni, restaurant2));
+        bookmarkRepository.save(createTestBookmark(ori, restaurant3));
+
+        String query = ORDER_BY_BOOKMARK_COUNT_DESC.getQuery();
+        Slice<Restaurant> page = restaurantQueryRepository.findPageByCampusIdAndCategoryId(query,
+                1L, 1L, PageRequest.of(0, 3));
+
+        assertThat(page).containsExactly(restaurant2, restaurant1, restaurant3);
     }
 
     @Test

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantQueryRepositoryTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantQueryRepositoryTest.java
@@ -120,7 +120,7 @@ public class RestaurantQueryRepositoryTest {
     }
 
     @Test
-    void 캠퍼스id와_카테고리id가_일치하는_식당을_가까운_거리순으로_페이징해서_반환한다() {
+    void 캠퍼스id와_카테고리id가_일치하는_식당을_가까운_거리순_가나다순으로_페이징해서_반환한다() {
         Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당1", "주소1", 5);
         Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당2", "주소2", 7);
         Restaurant restaurant3 = createTestRestaurant(1L, 1L, "식당3", "주소3", 6);
@@ -134,7 +134,7 @@ public class RestaurantQueryRepositoryTest {
     }
 
     @Test
-    void 캠퍼스id와_카테고리id가_일치하는_식당을_찜수가_많은순으로_페이징해서_반환한다() {
+    void 캠퍼스id와_카테고리id가_일치하는_식당을_찜수가_많은순_가나다순으로_페이징해서_반환한다() {
         Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당1", "주소1");
         Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당2", "주소2");
         Restaurant restaurant3 = createTestRestaurant(1L, 1L, "식당3", "주소3");

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantQueryRepositoryTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/infrastructure/restaurant/RestaurantQueryRepositoryTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.matzip.infrastructure.restaurant;
 import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestMember;
 import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestRestaurant;
 import static com.woowacourse.matzip.TestFixtureCreateUtil.createTestReview;
+import static com.woowacourse.matzip.infrastructure.restaurant.RestaurantFindQueryFactory.ORDER_BY_DISTANCE_ASC;
 import static com.woowacourse.matzip.infrastructure.restaurant.RestaurantFindQueryFactory.ORDER_BY_ID_DESC;
 import static com.woowacourse.matzip.infrastructure.restaurant.RestaurantFindQueryFactory.ORDER_BY_NAME_ASC;
 import static com.woowacourse.matzip.infrastructure.restaurant.RestaurantFindQueryFactory.ORDER_BY_RATING_DESC;
@@ -109,6 +110,20 @@ public class RestaurantQueryRepositoryTest {
         Slice<Restaurant> page = restaurantQueryRepository.findPageByCampusIdAndCategoryId(query, 1L, 1L,
                 PageRequest.of(0, 3));
         assertThat(page.getContent()).containsExactly(restaurant1, restaurant2, restaurant3);
+    }
+
+    @Test
+    void 캠퍼스id와_카테고리id가_일치하는_식당을_가까운_거리순으로_페이징해서_반환한다() {
+        Restaurant restaurant1 = createTestRestaurant(1L, 1L, "식당1", "주소1", 5);
+        Restaurant restaurant2 = createTestRestaurant(1L, 1L, "식당2", "주소2", 7);
+        Restaurant restaurant3 = createTestRestaurant(1L, 1L, "식당3", "주소3", 6);
+        restaurantRepository.saveAll(List.of(restaurant1, restaurant2, restaurant3));
+
+        String query = ORDER_BY_DISTANCE_ASC.getQuery();
+        Slice<Restaurant> page = restaurantQueryRepository.findPageByCampusIdAndCategoryId(query, 1L, 1L,
+                PageRequest.of(0, 3));
+
+        assertThat(page).containsExactly(restaurant1, restaurant3, restaurant2);
     }
 
     @Test

--- a/matzip-core/src/main/java/com/woowacourse/matzip/domain/restaurant/Restaurant.java
+++ b/matzip-core/src/main/java/com/woowacourse/matzip/domain/restaurant/Restaurant.java
@@ -56,9 +56,19 @@ public class Restaurant {
     }
 
     @Builder
-    public Restaurant(final Long id, final Long categoryId, final Long campusId, final String name,
-                      final String address, final long distance, final String kakaoMapUrl, final String imageUrl,
-                      final int reviewCount, final long reviewRatingSum, final float reviewRatingAverage) {
+    public Restaurant(
+            final Long id,
+            final Long categoryId,
+            final Long campusId,
+            final String name,
+            final String address,
+            final long distance,
+            final String kakaoMapUrl,
+            final String imageUrl,
+            final int reviewCount,
+            final long reviewRatingSum,
+            final float reviewRatingAverage
+    ) {
         LengthValidator.checkStringLength(name, MAX_NAME_LENGTH, "식당 이름");
         this.id = id;
         this.categoryId = categoryId;

--- a/matzip-core/src/testFixtures/java/com/woowacourse/matzip/TestFixtureCreateUtil.java
+++ b/matzip-core/src/testFixtures/java/com/woowacourse/matzip/TestFixtureCreateUtil.java
@@ -19,6 +19,18 @@ public class TestFixtureCreateUtil {
                 .build();
     }
 
+    public static Restaurant createTestRestaurant(Long categoryId, Long campusId, String name, String address, long distance) {
+        return Restaurant.builder()
+                .categoryId(categoryId)
+                .campusId(campusId)
+                .name(name)
+                .address(address)
+                .distance(distance)
+                .kakaoMapUrl("테스트URL")
+                .imageUrl("테스트URL")
+                .build();
+    }
+
     public static Restaurant createTestRestaurant(final Restaurant restaurant, final int reviewCount, final long reviewRatingSum, final float reviewRatingAverage) {
         return Restaurant.builder()
                 .id(restaurant.getId())

--- a/matzip-core/src/testFixtures/java/com/woowacourse/matzip/TestFixtureCreateUtil.java
+++ b/matzip-core/src/testFixtures/java/com/woowacourse/matzip/TestFixtureCreateUtil.java
@@ -8,7 +8,12 @@ import com.woowacourse.matzip.domain.review.Review;
 
 public class TestFixtureCreateUtil {
 
-    public static Restaurant createTestRestaurant(Long categoryId, Long campusId, String name, String address) {
+    public static Restaurant createTestRestaurant(
+            final Long categoryId,
+            final Long campusId,
+            final String name,
+            final String address
+    ) {
         return Restaurant.builder()
                 .categoryId(categoryId)
                 .campusId(campusId)
@@ -20,7 +25,13 @@ public class TestFixtureCreateUtil {
                 .build();
     }
 
-    public static Restaurant createTestRestaurant(Long categoryId, Long campusId, String name, String address, long distance) {
+    public static Restaurant createTestRestaurant(
+            final Long categoryId,
+            final Long campusId,
+            final String name,
+            final String address,
+            final long distance
+    ) {
         return Restaurant.builder()
                 .categoryId(categoryId)
                 .campusId(campusId)
@@ -32,7 +43,12 @@ public class TestFixtureCreateUtil {
                 .build();
     }
 
-    public static Restaurant createTestRestaurant(final Restaurant restaurant, final int reviewCount, final long reviewRatingSum, final float reviewRatingAverage) {
+    public static Restaurant createTestRestaurant(
+            final Restaurant restaurant,
+            final int reviewCount,
+            final long reviewRatingSum,
+            final float reviewRatingAverage
+    ) {
         return Restaurant.builder()
                 .id(restaurant.getId())
                 .categoryId(restaurant.getCategoryId())
@@ -63,7 +79,7 @@ public class TestFixtureCreateUtil {
                 .build();
     }
 
-    public static Review createTestReview(Member member, Long restaurantId, int rating) {
+    public static Review createTestReview(final Member member, final Long restaurantId, final int rating) {
         return Review.builder()
                 .member(member)
                 .restaurantId(restaurantId)
@@ -73,8 +89,12 @@ public class TestFixtureCreateUtil {
                 .build();
     }
 
-    public static RestaurantDemand createTestRestaurantDemand(Long categoryId, Long campusId, String name,
-                                                              Member member) {
+    public static RestaurantDemand createTestRestaurantDemand(
+            final Long categoryId,
+            final Long campusId,
+            final String name,
+            final Member member
+    ) {
         return RestaurantDemand.builder()
                 .categoryId(categoryId)
                 .campusId(campusId)

--- a/matzip-core/src/testFixtures/java/com/woowacourse/matzip/TestFixtureCreateUtil.java
+++ b/matzip-core/src/testFixtures/java/com/woowacourse/matzip/TestFixtureCreateUtil.java
@@ -1,5 +1,6 @@
 package com.woowacourse.matzip;
 
+import com.woowacourse.matzip.domain.bookmark.Bookmark;
 import com.woowacourse.matzip.domain.member.Member;
 import com.woowacourse.matzip.domain.restaurant.Restaurant;
 import com.woowacourse.matzip.domain.restaurant.RestaurantDemand;
@@ -52,6 +53,13 @@ public class TestFixtureCreateUtil {
                 .githubId("githubId")
                 .username("username")
                 .profileImage("url")
+                .build();
+    }
+
+    public static Bookmark createTestBookmark(final Member member, final Restaurant restaurant) {
+        return Bookmark.builder()
+                .member(member)
+                .restaurant(restaurant)
                 .build();
     }
 


### PR DESCRIPTION
## issue: #205 

## as-is

- `별점 순` 과 `가나다 순` 정렬만으로 원하는 조건을 맛집을 파악하기 힘들다.

## to-be

> 거리 순 정렬

- 기존의 거리 정보 데이터를 활용하여거리 순 오름차순 정렬 기능을 추가하여 가장 가까운 맛집을 빠르게 찾을 수 있도록 돕는다.
- 거리가 같을 경우 이름 기준으로 오름차순 정렬한다.

> 좋아요 순(찜 순) 정렬

- 좋아요 순 내림차순 정렬을 추가하여 "개인 소장 찐 맛집" 순서대로 볼 수 있도록 돕는다.
- 좋아요 수(찜 수)가 같을 경우 이름 기준으로 오름차순 정렬한다.