### PR TITLE
feat: 추천 검색어 자동완성 API 구현

### DIFF
--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -94,7 +94,7 @@ public class RestaurantService {
     }
 
     public RestaurantSearchesResponse findByRestaurantNamePrefix(final Long campusId, final String namePrefix, final Pageable pageable) {
-        List<Restaurant> restaurants = restaurantRepository.findByNamePrefix(campusId, namePrefix, pageable);
+        List<Restaurant> restaurants = restaurantRepository.findByNamePrefixOrderByLikeDesc(campusId, namePrefix, pageable);
 
         return RestaurantSearchesResponse.from(restaurants);
     }

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/RestaurantService.java
@@ -1,6 +1,7 @@
 package com.woowacourse.matzip.application;
 
 import com.woowacourse.matzip.application.response.RestaurantResponse;
+import com.woowacourse.matzip.application.response.RestaurantSearchesResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitlesResponse;
 import com.woowacourse.matzip.domain.bookmark.BookmarkRepository;
@@ -90,6 +91,12 @@ public class RestaurantService {
                 .orElseThrow(MemberNotFoundException::new);
         return bookmarkRepository.findBookmarkByMemberIdAndRestaurantId(member.getId(), restaurantId)
                 .isPresent();
+    }
+
+    public RestaurantSearchesResponse findByRestaurantNamePrefix(final Long campusId, final String namePrefix, final Pageable pageable) {
+        List<Restaurant> restaurants = restaurantRepository.findByNamePrefix(campusId, namePrefix, pageable);
+
+        return RestaurantSearchesResponse.from(restaurants);
     }
 
     public RestaurantTitlesResponse findTitlesByCampusIdAndNameContainingIgnoreCaseIdDescSort(final String githubId,

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantSearchResponse.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantSearchResponse.java
@@ -8,7 +8,7 @@ public class RestaurantSearchResponse {
     private Long id;
     private String name;
 
-    public RestaurantSearchResponse() {
+    private RestaurantSearchResponse() {
     }
 
     public RestaurantSearchResponse(Long id, String name) {

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantSearchResponse.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantSearchResponse.java
@@ -1,0 +1,22 @@
+package com.woowacourse.matzip.application.response;
+
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import lombok.Getter;
+
+@Getter
+public class RestaurantSearchResponse {
+    private Long id;
+    private String name;
+
+    public RestaurantSearchResponse() {
+    }
+
+    public RestaurantSearchResponse(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static RestaurantSearchResponse from(Restaurant restaurant) {
+        return new RestaurantSearchResponse(restaurant.getId(), restaurant.getName());
+    }
+}

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantSearchesResponse.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantSearchesResponse.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 @Getter
 public class RestaurantSearchesResponse {
-    List<RestaurantSearchResponse> restaurants;
+    private List<RestaurantSearchResponse> restaurants;
 
-    public RestaurantSearchesResponse() {
+    private RestaurantSearchesResponse() {
     }
 
     public RestaurantSearchesResponse(List<RestaurantSearchResponse> restaurants) {

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantSearchesResponse.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/application/response/RestaurantSearchesResponse.java
@@ -1,0 +1,26 @@
+package com.woowacourse.matzip.application.response;
+
+import com.woowacourse.matzip.domain.restaurant.Restaurant;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RestaurantSearchesResponse {
+    List<RestaurantSearchResponse> restaurants;
+
+    public RestaurantSearchesResponse() {
+    }
+
+    public RestaurantSearchesResponse(List<RestaurantSearchResponse> restaurants) {
+        this.restaurants = restaurants;
+    }
+
+    public static RestaurantSearchesResponse from(List<Restaurant> restaurants) {
+        List<RestaurantSearchResponse> items = restaurants.stream()
+                .map(RestaurantSearchResponse::from)
+                .toList();
+
+        return new RestaurantSearchesResponse(items);
+    }
+}

--- a/matzip-app-external-api/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
+++ b/matzip-app-external-api/src/main/java/com/woowacourse/matzip/presentation/RestaurantController.java
@@ -3,6 +3,7 @@ package com.woowacourse.matzip.presentation;
 import com.woowacourse.auth.support.AuthenticationPrincipal;
 import com.woowacourse.matzip.application.RestaurantService;
 import com.woowacourse.matzip.application.response.RestaurantResponse;
+import com.woowacourse.matzip.application.response.RestaurantSearchesResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitlesResponse;
 import java.util.List;
@@ -65,5 +66,11 @@ public class RestaurantController {
     public ResponseEntity<List<RestaurantTitleResponse>> showBookmarkedRestaurants(
             @AuthenticationPrincipal final String githubId) {
         return ResponseEntity.ok(restaurantService.findBookmarkedRestaurants(githubId));
+    }
+
+    @GetMapping("/campuses/{campusId}/restaurants/search/autocomplete")
+    public ResponseEntity<RestaurantSearchesResponse> autocompleteSearchRestaurants(@PathVariable final Long campusId,
+                                                                                        @RequestParam final String namePrefix) {
+        return ResponseEntity.ok(restaurantService.findByRestaurantNamePrefix(campusId, namePrefix, Pageable.ofSize(5)));
     }
 }

--- a/matzip-app-external-api/src/test/java/com/woowacourse/acceptance/BookmarkAcceptanceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/acceptance/BookmarkAcceptanceTest.java
@@ -20,7 +20,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         return httpPostRequest("/api/bookmarks/restaurants/" + restaurantId, accessToken);
     }
 
-    private static ExtractableResponse<Response> 북마크_삭제_요청(final Long restaurantId, final String accessToken) {
+    public static ExtractableResponse<Response> 북마크_삭제_요청(final Long restaurantId, final String accessToken) {
         return httpDeleteRequest("/api/bookmarks/restaurants/" + restaurantId, accessToken);
     }
 

--- a/matzip-app-external-api/src/test/java/com/woowacourse/acceptance/RestaurantAcceptanceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/acceptance/RestaurantAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.acceptance;
 
 import static com.woowacourse.acceptance.AuthAcceptanceTest.로그인_토큰;
+import static com.woowacourse.acceptance.BookmarkAcceptanceTest.북마크_삭제_요청;
 import static com.woowacourse.acceptance.BookmarkAcceptanceTest.북마크_저장_요청;
 import static com.woowacourse.acceptance.support.RestAssuredRequest.httpGetRequest;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,7 +14,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-public class RestaurantAcceptanceTest extends AcceptanceTest {
+class RestaurantAcceptanceTest extends AcceptanceTest {
 
     private static final Long 선릉캠퍼스_ID = 2L;
     private static final Long 한식_ID = 1L;
@@ -114,6 +115,8 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = 캠퍼스_식당_추천_검색어_자동완성_요청(선릉캠퍼스_ID, "마");
         캠퍼스_식당_추천_검색어_자동완성에_성공한다(response, 3,  "마담밍2", "마담밍", "마담밍3");
+
+        북마크_삭제_요청(식당_4_ID, accessToken);
     }
 
     private void 식당_조회에_성공한다(final ExtractableResponse<Response> response) {

--- a/matzip-app-external-api/src/test/java/com/woowacourse/acceptance/RestaurantAcceptanceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/acceptance/RestaurantAcceptanceTest.java
@@ -19,6 +19,7 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
     private static final Long 한식_ID = 1L;
     private static final Long 식당_1_ID = 1L;
     private static final Long 식당_2_ID = 2L;
+    private static final Long 식당_4_ID = 4L;
 
     private static ExtractableResponse<Response> 캠퍼스_식당_페이지_조회_요청(final Long campusId, final int page, final int size) {
         return httpGetRequest("/api/campuses/" + campusId + "/restaurants?page=" + page + "&size=" + size);
@@ -55,7 +56,7 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
         return httpGetRequest("/api/restaurants/bookmarks", accessToken);
     }
 
-    private static ExtractableResponse<Response> 캠퍼스_식당_자동_완성_검색_요청(final Long campusId, final String namePrefix) {
+    private static ExtractableResponse<Response> 캠퍼스_식당_추천_검색어_자동완성_요청(final Long campusId, final String namePrefix) {
         return httpGetRequest(
                 "/api/campuses/" + campusId + "/restaurants/search/autocomplete?namePrefix=" + namePrefix);
     }
@@ -107,9 +108,12 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 선릉캠퍼스_식당_중_입력받은_접두사로_시작하는_이름의_식당을_최대_5개_조회한다() {
-        ExtractableResponse<Response> response = 캠퍼스_식당_자동_완성_검색_요청(선릉캠퍼스_ID, "마");
-        식당_자동완성_검색에_성공한다(response, 3, "마담밍", "마담밍2", "마담밍3");
+    void 선릉캠퍼스_식당_중_입력받은_접두사로_시작하는_이름의_식당을_좋아요_기준_내림차순으로_최대_5개_추천한다() {
+        String accessToken = 로그인_토큰();
+        북마크_저장_요청(식당_4_ID, accessToken);
+
+        ExtractableResponse<Response> response = 캠퍼스_식당_추천_검색어_자동완성_요청(선릉캠퍼스_ID, "마");
+        캠퍼스_식당_추천_검색어_자동완성에_성공한다(response, 3,  "마담밍2", "마담밍", "마담밍3");
     }
 
     private void 식당_조회에_성공한다(final ExtractableResponse<Response> response) {
@@ -140,11 +144,11 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    private void 식당_자동완성_검색에_성공한다(final ExtractableResponse<Response> response, int size, String... names) {
+    private void 캠퍼스_식당_추천_검색어_자동완성에_성공한다(final ExtractableResponse<Response> response, int size, String... names) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.as(RestaurantSearchesResponse.class).getRestaurants()).extracting("name")
-                        .contains(names),
+                        .containsExactly(names),
                 () -> assertThat(response.as(RestaurantSearchesResponse.class).getRestaurants()).hasSize(size)
         );
     }

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/BookmarkServiceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/BookmarkServiceTest.java
@@ -36,7 +36,7 @@ public class BookmarkServiceTest {
     @Test
     void 북마크를_삭제한다() {
         Member member = memberRepository.save(ORI.toMember());
-        Restaurant restaurant = restaurantRepository.findAll().get(3);
+        Restaurant restaurant = restaurantRepository.findAll().get(2);
         bookmarkService.createBookmark(member.getGithubId(), restaurant.getId());
 
         assertDoesNotThrow(

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -343,8 +343,9 @@ class RestaurantServiceTest {
                 Pageable.ofSize(5)
         ).getRestaurants();
 
-        assertThat(response).hasSize(3)
+
+        assertThat(response)
                 .extracting("name")
-                .containsAnyOf("마담밍", "마담밍2", "마담밍3");
+                .containsExactly("마담밍", "마담밍2", "마담밍3");
     }
 }

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.matzip.application.response.RestaurantResponse;
+import com.woowacourse.matzip.application.response.RestaurantSearchResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitleResponse;
 import com.woowacourse.matzip.application.response.RestaurantTitlesResponse;
 import com.woowacourse.matzip.domain.member.Member;
@@ -21,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @SpringServiceTest
 class RestaurantServiceTest {
@@ -331,5 +333,18 @@ class RestaurantServiceTest {
         assertThat(response)
                 .extracting(RestaurantTitleResponse::getReviewCount)
                 .containsExactlyInAnyOrder(4, 3);
+    }
+
+    @Test
+    void 캠퍼스의_식당_중_입력받은_접두사로_시작하는_이름의_식당을_조회한다() {
+        List<RestaurantSearchResponse> response = restaurantService.findByRestaurantNamePrefix(
+                2L,
+                "마",
+                Pageable.ofSize(5)
+        ).getRestaurants();
+
+        assertThat(response).hasSize(3)
+                .extracting("name")
+                .containsAnyOf("마담밍", "마담밍2", "마담밍3");
     }
 }

--- a/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
+++ b/matzip-app-external-api/src/test/java/com/woowacourse/matzip/application/RestaurantServiceTest.java
@@ -336,7 +336,7 @@ class RestaurantServiceTest {
     }
 
     @Test
-    void 캠퍼스의_식당_중_입력받은_접두사로_시작하는_이름의_식당을_조회한다() {
+    void 캠퍼스의_식당_중_입력받은_접두사로_시작하는_이름의_식당을_좋아요_기준_내림차순으로_조회한다() {
         List<RestaurantSearchResponse> response = restaurantService.findByRestaurantNamePrefix(
                 2L,
                 "마",

--- a/matzip-core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
+++ b/matzip-core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
@@ -23,8 +23,12 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     @Query("select r " +
             "from Restaurant r " +
-            "where r.campusId = :campusId and r.name like CONCAT(:namePrefix, '%')")
-    List<Restaurant> findByNamePrefix(Long campusId, String namePrefix, Pageable pageable);
+            "left join Bookmark b on b.restaurant = r " +
+            "where r.campusId = :campusId and r.name like CONCAT(:namePrefix, '%') " +
+            "group by r " +
+            "order by count(b) desc"
+    )
+    List<Restaurant> findByNamePrefixOrderByLikeDesc(Long campusId, String namePrefix, Pageable pageable);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "update Restaurant r "

--- a/matzip-core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
+++ b/matzip-core/src/main/java/com/woowacourse/matzip/domain/restaurant/RestaurantRepository.java
@@ -20,6 +20,12 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     Slice<Restaurant> findPageByCampusIdAndNameContainingIgnoreCase(Long campusId, String name, Pageable pageable);
 
+
+    @Query("select r " +
+            "from Restaurant r " +
+            "where r.campusId = :campusId and r.name like CONCAT(:namePrefix, '%')")
+    List<Restaurant> findByNamePrefix(Long campusId, String namePrefix, Pageable pageable);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "update Restaurant r "
             + "set r.reviewRatingAverage = (r.reviewRatingSum + :rating) / cast((r.reviewCount + 1) as float), "


### PR DESCRIPTION
## issue: #207 

## as-is
식당 검색 시에 자동완성 기능이 없어서 실제로 검색해보지 않으면 검색어와 관련된 이름의 식당이 어떤 것이 있는 지 알 수 있었습니다.
이로인해 사용자들이 불편을 겪고 있음을 파악하여 이를 수정해보고자 하였습니다.

## to-be
- 식당 검색 시, 사용자들의 사용성을 높이기 위해 자동완성 기능을 구현하였습니다.
  - 자동완성을 통해 조회할 수 있는 식당의 개수는 최대 5개입니다.

- 자동완성으로 조회되는 데이터는 좋아요 기준 내림차순으로 정렬합니다.

처음엔 정렬을 할 지 말 지 고민이 있었는데요.
고민의 이유는 '검색어 자동완성' 이라는 맥락 때문이었습니자.
"자동완성은 그냥 검색어에 일치하는 데이터를 보여주는 거지 추천까지 해도 되는걸까?" 라는 생각이었습니다.
네이버 같은 보통의 검색 서비스도 최신순/정확도순 으로 자동완성을 만드는 것 같았어요.

하지만 이러한 최신순/정확도순이라는 기준은 평가하기 어려운 다양한 주제를 모두 다루는 경우 사용될 수 있는 기준이라고 생각합니다.
저희 서비스는 `맛집 추천`이라는 기준을 가지고 있기 때문에 자동완성의 기준을 더 다양하게 잡아볼 수 있을 것 같아요.
그래서 결론적으로 좋아요 수를 기준으로 자동완성을 처리해보도록 하겠습니다.
추가로 맥락에 맞게 '검색어 자동완성'보다는 '검색어 추천'이라고 생각하고 코드를 작성해보았습니다.

## 의견

### 조회 size 조절은 서버에서

```java
@GetMapping("/campuses/{campusId}/restaurants/search/autocomplete")
    public ResponseEntity<RestaurantSearchesResponse> autocompleteSearchRestaurants(@PathVariable final Long campusId,
                                                                                        @RequestParam final String namePrefix) {
        return ResponseEntity.ok(restaurantService.findByRestaurantNamePrefix(campusId, namePrefix, Pageable.ofSize(5)));
    }
```

```java
public RestaurantSearchesResponse findByRestaurantNamePrefix(final Long campusId, final String namePrefix, final Pageable pageable) {
        List<Restaurant> restaurants = restaurantRepository.findByNamePrefix(campusId, namePrefix, pageable);

        return RestaurantSearchesResponse.from(restaurants);
    }
```

조회 size 제한 설정을 Request Parameter를 통해 클라이언트 측에 맡기면,
URL을 통해 원하는 size만큼 요청이 가능하기 때문에 악의적인 요청이 반복적으로 발생하는 경우 메모리 관련 문제로 이어질 수 있다는 생각에
size를 서버에서 조절하도록 로직을 작성하였습니다.
이 부분에 대한 의견도 함께 주시면 감사하겠습니다.

